### PR TITLE
Added all remaining Broadcast methods, added PlayerBan event, added LockerInteract event

### DIFF
--- a/EXILED_Events/EXILED_Events.csproj
+++ b/EXILED_Events/EXILED_Events.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Patches\914MachineOverride.cs" />
     <Compile Include="Patches\AntiFlyOverride.cs" />
     <Compile Include="Patches\BanHandlerOverride.cs" />
+    <Compile Include="Patches\BanUserOverride.cs" />
     <Compile Include="Patches\CheaterReportOverride.cs" />
     <Compile Include="Patches\CheckEscapeEvent.cs" />
     <Compile Include="Patches\CheckRoundEndEvent.cs" />

--- a/EXILED_Events/EXILED_Events.csproj
+++ b/EXILED_Events/EXILED_Events.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Patches\CheaterReportOverride.cs" />
     <Compile Include="Patches\CheckEscapeEvent.cs" />
     <Compile Include="Patches\CheckRoundEndEvent.cs" />
+    <Compile Include="Patches\LockerEventOverride.cs" />
     <Compile Include="Patches\SyncDataEvent.cs" />
     <Compile Include="Patches\DecontaminationEvent.cs" />
     <Compile Include="Patches\DoorInteractionEvent.cs" />

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -124,6 +124,19 @@ namespace EXILED
 		public Door Door { get; set; }
 		public bool Allow { get; set; }
 	}
+	public class LockerInteractionEvent : EventArgs
+	{
+		public readonly ReferenceHub Player;
+		public readonly Locker Locker;
+		public readonly int LockerId;
+		public LockerInteractionEvent(ReferenceHub rh, Locker locker, int lockerId)
+		{
+			Player = rh;
+			Locker = locker;
+			LockerId = lockerId;
+		}
+		public bool Allow { get; set; }
+	}
 
 	public class PlayerLeaveEvent : EventArgs
 	{

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -297,9 +297,9 @@ namespace EXILED
 		private readonly bool log;
 		private string userId;
 		private int duration;
+		private ReferenceHub bannedPlayer;
+		private bool allow = true;
 
-		public readonly ReferenceHub BannedPlayer;
-		
 		public string Reason;
 		public string FullMessage;
 
@@ -308,7 +308,6 @@ namespace EXILED
 			this.log = log;
 			this.userId = userId;
 			this.duration = duration;
-			BannedPlayer = bannedPlayer;
 			Reason = reason;
 
 			// Set to true in the constructor to avoid triggering the logs.
@@ -338,9 +337,11 @@ namespace EXILED
 			{
 				if (userId == value) return;
 
+				if (userId == null) userId = "(null)";
+				
 				if(log)
 					LogBanChange(Assembly.GetCallingAssembly().GetName().Name
-					+ $" changed UserID: {userId} to {value}");
+					+ $" changed UserID from {userId} to {value}");
 
 				userId = value;
 			}
@@ -349,7 +350,6 @@ namespace EXILED
 				return userId;
 			}
 		}
-		private bool allow = true;
 		public bool Allow
 		{
 			set
@@ -365,6 +365,21 @@ namespace EXILED
 			get 
 			{
 				return allow;
+			}
+		}
+		public ReferenceHub BannedPlayer
+		{
+			set
+			{
+				if (value == null || BannedPlayer == value) return;
+				if (log)
+					LogBanChange(Assembly.GetCallingAssembly().GetName().Name
+					+ $" changed the banned player from user {bannedPlayer.nicknameSync.Network_myNickSync} ({bannedPlayer.characterClassManager.UserId}) to {value.nicknameSync.Network_myNickSync} ({value.characterClassManager.UserId})");
+				bannedPlayer = value;
+			}
+			get
+			{
+				return bannedPlayer;
 			}
 		}
 		private void LogBanChange(string msg)

--- a/EXILED_Events/Events/MapEvents.cs
+++ b/EXILED_Events/Events/MapEvents.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using EXILED.Extensions;
 using UnityEngine;
@@ -50,7 +51,23 @@ namespace EXILED
 			onDoorInteract?.Invoke(ref ev);
 			allow = ev.Allow;
 		}
-		
+
+		public static event OnLockerInteract LockerInteractEvent;
+		public delegate void OnLockerInteract(LockerInteractionEvent ev);
+
+		internal static void InvokeLockerInteract(GameObject gameObject, Locker locker, int lockerid, ref bool allow)
+		{
+			OnLockerInteract onLockerInteract = LockerInteractEvent;
+			if (onLockerInteract == null)
+				return;
+			LockerInteractionEvent ev = new LockerInteractionEvent(Player.GetPlayer(gameObject), locker, lockerid)
+			{
+				Allow = allow,
+			};
+			onLockerInteract?.Invoke(ev);
+			allow = ev.Allow;
+		}
+
 		public static event TriggerTesla TriggerTeslaEvent;
 		public delegate void TriggerTesla(ref TriggerTeslaEvent ev);
 		public static void InvokeTriggerTesla(GameObject obj, bool hurtRange, ref bool triggerable)

--- a/EXILED_Events/Events/ServerEvents.cs
+++ b/EXILED_Events/Events/ServerEvents.cs
@@ -146,7 +146,7 @@ namespace EXILED
 		public static event PlayerBan PlayerBanEvent;
 		public delegate void PlayerBan(PlayerBanEvent ev);
 
-		public static void InvokePlayerBan(ReferenceHub user, ref string userId, ref int duration, ref bool allow, ref string message, ref string reason)
+		public static void InvokePlayerBan(ref ReferenceHub user, ref string userId, ref int duration, ref bool allow, ref string message, ref string reason)
 		{
 			PlayerBan playerBan = PlayerBanEvent;
 			if (playerBan == null)
@@ -165,6 +165,7 @@ namespace EXILED
 			duration = ev.Duration;
 			message = ev.FullMessage;
 			reason = ev.Reason;
+			user = ev.BannedPlayer;
 		}
 
 		public static event SetGroup SetGroupEvent;

--- a/EXILED_Events/Events/ServerEvents.cs
+++ b/EXILED_Events/Events/ServerEvents.cs
@@ -143,6 +143,29 @@ namespace EXILED
 			PlayerBannedEvent?.Invoke(ev);
 		}
 
+		public static event PlayerBan PlayerBanEvent;
+		public delegate void PlayerBan(PlayerBanEvent ev);
+
+		public static void InvokePlayerBan(ReferenceHub user, ref string userId, ref int duration, ref bool allow, ref string message, ref string reason)
+		{
+			PlayerBan playerBan = PlayerBanEvent;
+			if (playerBan == null)
+				return;
+			// ev.Allow is already set to true in the constructor
+			// Private field values set in the constructor to avoid triggering the logs
+			PlayerBanEvent ev = new PlayerBanEvent(Plugin.Config.GetBool("exiled_log_ban_event", true), user, reason, userId, duration)
+			{
+				FullMessage = message,
+				Reason = reason
+			};
+
+			playerBan?.Invoke(ev);
+			allow = ev.Allow;
+			userId = ev.UserId;
+			duration = ev.Duration;
+			message = ev.FullMessage;
+			reason = ev.Reason;
+		}
 
 		public static event SetGroup SetGroupEvent;
 		public delegate void SetGroup(SetGroupEvent ev);

--- a/EXILED_Events/Patches/BanUserOverride.cs
+++ b/EXILED_Events/Patches/BanUserOverride.cs
@@ -1,0 +1,20 @@
+﻿using Harmony;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace EXILED.Patches
+{
+    [HarmonyPatch(typeof(BanPlayer), nameof(BanPlayer.BanUser))]
+    public class BanUserOverride
+    {
+        public static bool Prefix(GameObject user, int duration, string reason, string issuer, bool isGlobalBan)
+        {
+
+            return false;
+        }
+    }
+}

--- a/EXILED_Events/Patches/BanUserOverride.cs
+++ b/EXILED_Events/Patches/BanUserOverride.cs
@@ -44,7 +44,7 @@ namespace EXILED.Patches
 			try
 			{
 				bool allow = true;
-				Events.InvokePlayerBan(userHub, ref userId, ref duration, ref allow, ref message, ref reason);
+				Events.InvokePlayerBan(ref userHub, ref userId, ref duration, ref allow, ref message, ref reason);
 
 				if (!allow)
 					return false;

--- a/EXILED_Events/Patches/BanUserOverride.cs
+++ b/EXILED_Events/Patches/BanUserOverride.cs
@@ -1,4 +1,6 @@
-﻿using Harmony;
+﻿using GameCore;
+using Harmony;
+using Mirror;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,8 +15,117 @@ namespace EXILED.Patches
     {
         public static bool Prefix(GameObject user, int duration, string reason, string issuer, bool isGlobalBan)
         {
+			if (isGlobalBan && ConfigFile.ServerConfig.GetBool("gban_ban_ip", false))
+			{
+				duration = int.MaxValue;
+			}
+			string userId = null;
+			string address = user.GetComponent<NetworkIdentity>().connectionToClient.address;
+			CharacterClassManager characterClassManager = null;
+			ReferenceHub userHub = Extensions.Player.GetPlayer(user);
+			try
+			{
+				if (ConfigFile.ServerConfig.GetBool("online_mode", false))
+				{
+					characterClassManager = userHub.characterClassManager;
+					userId = characterClassManager.UserId;
+				}
+			}
+			catch
+			{
+				ServerConsole.AddLog("Failed during issue of User ID ban (1)!");
+				return false;
+			}
+			string message = $"You have been {((duration > 0) ? "banned" : "kicked")}. ";
+			if (!string.IsNullOrEmpty(reason))
+			{
+				message = message + "Reason: " + reason;
+			}
+			try
+			{
+				bool allow = true;
+				Events.InvokePlayerBan(userHub, ref userId, ref duration, ref allow, ref message, ref reason);
 
-            return false;
+				if (!allow)
+					return false;
+			}
+			catch (Exception ex)
+			{
+				Log.Error($"Error in OnBanPlayer event: {ex.ToString()}");
+			}
+
+			if (duration > 0 && (!ServerStatic.PermissionsHandler.IsVerified || !userHub.serverRoles.BypassStaff))
+			{
+				string originalName = string.IsNullOrEmpty(userHub.nicknameSync.MyNick) ? "(no nick)" : userHub.nicknameSync.MyNick;
+				long issuanceTime = TimeBehaviour.CurrentTimestamp();
+				long banExpieryTime = TimeBehaviour.GetBanExpieryTime((uint)duration);
+				try
+				{
+					if (userId != null && !isGlobalBan)
+					{
+						BanHandler.IssueBan(new BanDetails
+						{
+							OriginalName = originalName,
+							Id = userId,
+							IssuanceTime = issuanceTime,
+							Expires = banExpieryTime,
+							Reason = reason,
+							Issuer = issuer
+						}, BanHandler.BanType.UserId);
+						if (!string.IsNullOrEmpty(characterClassManager.UserId2))
+						{
+							BanHandler.IssueBan(new BanDetails
+							{
+								OriginalName = originalName,
+								Id = characterClassManager.UserId2,
+								IssuanceTime = issuanceTime,
+								Expires = banExpieryTime,
+								Reason = reason,
+								Issuer = issuer
+							}, BanHandler.BanType.UserId);
+						}
+					}
+				}
+				catch
+				{
+					ServerConsole.AddLog("Failed during issue of User ID ban (2)!");
+					return false;
+				}
+				try
+				{
+					if (ConfigFile.ServerConfig.GetBool("ip_banning", false) || isGlobalBan)
+					{
+						BanHandler.IssueBan(new BanDetails
+						{
+							OriginalName = originalName,
+							Id = address,
+							IssuanceTime = issuanceTime,
+							Expires = banExpieryTime,
+							Reason = reason,
+							Issuer = issuer
+						}, BanHandler.BanType.IP);
+					}
+				}
+				catch
+				{
+					ServerConsole.AddLog("Failed during issue of IP ban!");
+					return false;
+				}
+			}
+			List<GameObject> playersToBan = new List<GameObject>();
+			foreach (GameObject gameObject in PlayerManager.players)
+			{
+				characterClassManager = gameObject.GetComponent<CharacterClassManager>();
+				if ((userId != null && characterClassManager.UserId == userId) || (address != null && characterClassManager.connectionToClient.address == address))
+				{
+					playersToBan.Add(characterClassManager.gameObject);
+				}
+			}
+			foreach (GameObject player in playersToBan)
+			{
+				ServerConsole.Disconnect(player, message);
+			}
+			return false;
         }
     }
 }

--- a/EXILED_Events/Patches/LockerEventOverride.cs
+++ b/EXILED_Events/Patches/LockerEventOverride.cs
@@ -1,0 +1,68 @@
+﻿using Harmony;
+
+namespace EXILED.Patches
+{
+	[HarmonyPatch(typeof(PlayerInteract), nameof(PlayerInteract.CallCmdUseLocker))]
+	class LockerEventOverride
+	{
+		public static bool Prefix(PlayerInteract __instance, int lockerId, int chamberNumber)
+		{
+			if (!__instance._playerInteractRateLimit.CanExecute(true) || (__instance._hc.CufferId > 0 && !__instance.CanDisarmedInteract))
+			{
+				return false;
+			}
+			LockerManager singleton = LockerManager.singleton;
+			if (lockerId < 0 || lockerId >= singleton.lockers.Length)
+			{
+				return false;
+			}
+			if (!__instance.ChckDis(singleton.lockers[lockerId].gameObject.position) || !singleton.lockers[lockerId].supportsStandarizedAnimation)
+			{
+				return false;
+			}
+			if (chamberNumber < 0 || chamberNumber >= singleton.lockers[lockerId].chambers.Length)
+			{
+				return false;
+			}
+			if (singleton.lockers[lockerId].chambers[chamberNumber].doorAnimator == null)
+			{
+				return false;
+			}
+			if (!singleton.lockers[lockerId].chambers[chamberNumber].CooldownAtZero())
+			{
+				return false;
+			}
+			singleton.lockers[lockerId].chambers[chamberNumber].SetCooldown();
+			string accessToken = singleton.lockers[lockerId].chambers[chamberNumber].accessToken;
+			Item itemByID = __instance._inv.GetItemByID(__instance._inv.curItem);
+			bool allow = string.IsNullOrEmpty(accessToken) || (itemByID != null && itemByID.permissions.Contains(accessToken)) || __instance._sr.BypassMode;
+			Events.InvokeLockerInteract(__instance.gameObject, singleton.lockers[lockerId], lockerId, ref allow);
+			if (allow)
+			{
+				bool flag = ((int)singleton.openLockers[lockerId] & 1 << chamberNumber) != 1 << chamberNumber;
+				singleton.ModifyOpen(lockerId, chamberNumber, flag);
+				singleton.RpcDoSound(lockerId, chamberNumber, flag);
+				bool state = true;
+				for (int i = 0; i < singleton.lockers[lockerId].chambers.Length; i++)
+				{
+					if (((int)singleton.openLockers[lockerId] & 1 << i) == 1 << i)
+					{
+						state = false;
+						break;
+					}
+				}
+				singleton.lockers[lockerId].LockPickups(state);
+				if (!string.IsNullOrEmpty(accessToken))
+				{
+					singleton.RpcChangeMaterial(lockerId, chamberNumber, false);
+				}
+			}
+			else
+			{
+				singleton.RpcChangeMaterial(lockerId, chamberNumber, true);
+			}
+			__instance.OnInteract();
+			return false;
+		}
+	}
+}

--- a/EXILED_Main/Extensions/MapExtensions.cs
+++ b/EXILED_Main/Extensions/MapExtensions.cs
@@ -7,6 +7,7 @@ namespace EXILED.Extensions
 	{
 		private static Inventory _hostInventory;
 		private static AlphaWarheadController _alphaWarheadController;
+		private static Broadcast _broadcast;
 		public static Inventory HostInventory
 		{
 			get
@@ -29,6 +30,17 @@ namespace EXILED.Extensions
 				return _alphaWarheadController;
 			}
 		}
+		internal static Broadcast BroadcastComponent
+		{
+			get
+			{
+				if(_broadcast == null)
+				{
+					_broadcast = PlayerManager.localPlayer.GetComponent<Broadcast>();
+				}
+				return _broadcast;
+			}
+		}
 		
 		/// <summary>
 		/// Spawns an item of type <paramref name="itemType"/> in a desired <paramref name="position"/>.
@@ -43,8 +55,16 @@ namespace EXILED.Extensions
 		/// <returns>The <see cref="Pickup"/></returns>
 		public static Pickup SpawnItem(ItemType itemType, float durability, Vector3 position, Quaternion rotation = default, int sight = 0, int barrel = 0, int other = 0)
 			=> HostInventory.SetPickup(itemType, durability, position, rotation, sight, barrel, other);
-		
-			/// <summary>
+		/// <summary>
+		/// Broadcasts a message to all players.
+		/// </summary>
+		/// <param name="message">What will be broadcasted (supports Unity Rich Text formatting)</param>
+		/// <param name="duration">The duration in seconds</param>
+		/// <param name="monospace">If the message should be in monospace</param>
+		public static void Broadcast(string message, uint duration, bool monospace = false)
+			=> BroadcastComponent.RpcAddElement(message, duration, monospace);
+		public static void ClearBroadcasts() => BroadcastComponent.RpcClearElements();
+		/// <summary>
 		/// Starts the warhead.
 		/// </summary>
 		public static void StartWarhead() => AlphaWarheadController.StartDetonation();

--- a/EXILED_Main/Extensions/PlayerExtensions.cs
+++ b/EXILED_Main/Extensions/PlayerExtensions.cs
@@ -181,8 +181,12 @@ namespace EXILED.Extensions
         /// <summary>
         /// A simple broadcast to a player. Doesn't get logged to the console.
         /// </summary>
-        public static void Broadcast(this ReferenceHub rh, uint time, string message) => rh.GetComponent<Broadcast>().TargetAddElement(rh.scp079PlayerScript.connectionToClient, message, time, false);
-        
+        public static void Broadcast(this ReferenceHub rh, uint time, string message) => Map.BroadcastComponent.TargetAddElement(rh.scp079PlayerScript.connectionToClient, message, time, false);
+        /// <summary>
+        /// Clears the brodcast of a player. Doesn't get logged to the console.
+        /// </summary>
+        /// <param name="rh"></param>
+        public static void ClearBroadcasts(this ReferenceHub rh) => Map.BroadcastComponent.TargetClearElements(rh.scp079PlayerScript.connectionToClient);
         /// <summary>
         /// Gets the team a player belongs to.
         /// </summary>


### PR DESCRIPTION
## Broadcast
- `Map.Broadcast(string message, uint duration, bool monospace)`, sends a global broadcast.
- `Map.ClearBroadcasts()`, clears all broadcasts.
- `Player.ClearBroadcasts()`, .NET Extension Method. Clears the broadcasts of a player.

## PlayerBan Event
Will be triggered before a ban is issued.
Contains: 
- `UserId`, set/get the UserId that will be written to the file.
- `Duration`, set/get the duration of the ban (in minutes).
- `BannedPlayer`, set/get the ReferenceHub of the player that will be disconnected.
- `Allow`, set/get if the player should be banned or not (true by default).
- `Reason`, set/get the reason.
- `FullMessage`, the message that will be broadcasted to the player.

## LockerInteract Event
Will be triggered everytime a player interacts with a locker.
Contains:
- `Player`, ReferenceHub of the player.
- `Locker`, the Locker that was triggered.
- `LockerId`, the id of the locker (int)
- `Allow`, set/get bool that will say if the locker will be opened or not.