### PR TITLE
fix for death by 207 was not triggered.

### DIFF
--- a/EXILED_Events/Patches/PlayerHurtEvent.cs
+++ b/EXILED_Events/Patches/PlayerHurtEvent.cs
@@ -34,7 +34,7 @@ namespace EXILED.Patches
 				else
 					Events.InvokePlayerHurt(__instance, ref info, go);
 
-				if (info.Amount >= go.GetComponent<PlayerStats>().health)
+				if (info.Amount >= go.GetComponent<PlayerStats>().health || (go.GetComponent<PlayerStats>().health - info.Amount) <= 1f)
 				{
 					CharacterClassManager ccm = go.GetComponent<CharacterClassManager>();
 					if (ccm != null)


### PR DESCRIPTION
SCP 207 can damage the player in lower than 1 float damage based on the player's speed.

Player will die nevertheless when the HP is lower than 1f. So added that check for the event to fire correctly for SCP 207.