### PR TITLE
Made PlayerHurtEvent more intuitive and easier to use, fixed PlayerBan, obsoleted the old Broadcast function

### DIFF
--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -366,6 +366,7 @@ namespace EXILED
 			this.log = log;
 			this.userId = userId;
 			this.duration = duration;
+			this.bannedPlayer = bannedPlayer;
 			Reason = reason;
 
 			// Set to true in the constructor to avoid triggering the logs.

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -48,9 +48,67 @@ namespace EXILED
 
     public class PlayerHurtEvent : EventArgs
 	{
+		private PlayerStats.HitInfo info;
 		public ReferenceHub Player { get; set; }
 		public ReferenceHub Attacker { get; set; }
-		public PlayerStats.HitInfo Info { get; set; }
+		private DamageTypes.DamageType damageType = DamageTypes.None;
+
+		public int Time
+		{
+			get
+			{
+				return info.Time;
+			}
+		}
+		/// <summary>
+		/// The DamageType as a <see cref="DamageTypes.DamageType"/>
+		/// </summary>
+		public DamageTypes.DamageType DamageType
+		{
+			get 
+			{
+				if (damageType == DamageTypes.None)
+					damageType = DamageTypes.FromIndex(info.Tool);
+				return damageType;
+			}
+		}
+		/// <summary>
+		/// The DamageType's <see cref="int"/> value
+		/// </summary>
+		public int Tool
+		{
+			get 
+			{
+				return info.Tool;
+			}
+		}
+		/// <summary>
+		/// The amount of damage to be dealt
+		/// </summary>
+		public float Amount
+		{
+			get 
+			{
+				return info.Amount;
+			}
+			set 
+			{
+				info.Amount = value;
+			}
+		}
+
+		public PlayerStats.HitInfo Info
+		{ 
+			get
+			{
+				return info;
+			}
+			set
+			{
+				damageType = DamageTypes.None;
+				info = value;
+			}
+		}
 	}
 
 	public class PlayerDeathEvent : EventArgs

--- a/EXILED_Main/Extensions/PlayerExtensions.cs
+++ b/EXILED_Main/Extensions/PlayerExtensions.cs
@@ -185,6 +185,7 @@ namespace EXILED.Extensions
         /// <summary>
         /// A simple broadcast to a player. Doesn't get logged to the console.
         /// </summary>
+        [Obsolete("Append ', false' to your broadcasts to use the new, updated method.", true)]
         public static void Broadcast(this ReferenceHub rh, uint time, string message) => Map.BroadcastComponent.TargetAddElement(rh.scp079PlayerScript.connectionToClient, message, time, false);
         /// <summary>
         /// Clears the brodcast of a player. Doesn't get logged to the console.


### PR DESCRIPTION
No need to obsolete the old members, but I would recommend it if you want an accurate `Time`.

### Added:
- `Time`, gets the time when the bullet was shot (inaccurate if changed with `Info = new Info...`
- `Amount`, can set/get the amount with this simple property. Cool.
- `Tool`, int representation of the "tool" used if you need it for whatever reason.
- `DamageType`, which returns the `DamageTypes.DamageType` (gets computed only if used, doesn't get recomputed if it's not `DamageType.None`)