### PR TITLE
Several Fixes and Added "Issuer" Referencehub to PlayerBanEvent

### DIFF
--- a/EXILED_Events/EXILED_Events.csproj
+++ b/EXILED_Events/EXILED_Events.csproj
@@ -93,9 +93,6 @@
     <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\References\UnityEngine.InputModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\References\UnityEngine.Networking.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\References\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -371,17 +371,19 @@ namespace EXILED
 		private string userId;
 		private int duration;
 		private ReferenceHub bannedPlayer;
+		private ReferenceHub issuer;
 		private bool allow = true;
 
 		public string Reason;
 		public string FullMessage;
 
-		public PlayerBanEvent(bool log, ReferenceHub bannedPlayer, string reason, string userId, int duration)
+		public PlayerBanEvent(bool log, ReferenceHub bannedPlayer, string reason, string userId, int duration, ReferenceHub issuer)
 		{
 			this.log = log;
 			this.userId = userId;
 			this.duration = duration;
 			this.bannedPlayer = bannedPlayer;
+			this.issuer = issuer;
 			Reason = reason;
 
 			// Set to true in the constructor to avoid triggering the logs.
@@ -454,6 +456,21 @@ namespace EXILED
 			get
 			{
 				return bannedPlayer;
+			}
+		}
+		public ReferenceHub Issuer
+		{
+			set
+			{
+				if (value == null || issuer == value) return;
+				if (log)
+					LogBanChange(Assembly.GetCallingAssembly().GetName().Name
+					             + $" changed the ban issuer from user {issuer.nicknameSync.Network_myNickSync} ({issuer.characterClassManager.UserId}) to {value.nicknameSync.Network_myNickSync} ({value.characterClassManager.UserId})");
+				issuer = value;
+			}
+			get
+			{
+				return issuer;
 			}
 		}
 		private void LogBanChange(string msg)

--- a/EXILED_Events/Events/ServerEvents.cs
+++ b/EXILED_Events/Events/ServerEvents.cs
@@ -146,13 +146,13 @@ namespace EXILED
 		public static event PlayerBan PlayerBanEvent;
 		public delegate void PlayerBan(PlayerBanEvent ev);
 
-		public static void InvokePlayerBan(ref ReferenceHub user, ref string userId, ref int duration, ref bool allow, ref string message, ref string reason)
+		public static void InvokePlayerBan(ref ReferenceHub user, ref string userId, ref int duration, ref bool allow, ref string message, ref string reason, ref ReferenceHub issuer)
 		{
 			if (PlayerBanEvent == null)
 				return;
 			// ev.Allow is already set to true in the constructor
 			// Private field values set in the constructor to avoid triggering the logs
-			PlayerBanEvent ev = new PlayerBanEvent(Plugin.Config.GetBool("exiled_log_ban_event", true), user, reason, userId, duration)
+			PlayerBanEvent ev = new PlayerBanEvent(Plugin.Config.GetBool("exiled_log_ban_event", true), user, reason, userId, duration, issuer)
 			{
 				FullMessage = message,
 				Reason = reason
@@ -165,6 +165,7 @@ namespace EXILED
 			message = ev.FullMessage;
 			reason = ev.Reason;
 			user = ev.BannedPlayer;
+			issuer = ev.Issuer;
 		}
 
 		public static event SetGroup SetGroupEvent;

--- a/EXILED_Events/Patches/BanUserOverride.cs
+++ b/EXILED_Events/Patches/BanUserOverride.cs
@@ -23,6 +23,7 @@ namespace EXILED.Patches
 			string address = user.GetComponent<NetworkIdentity>().connectionToClient.address;
 			CharacterClassManager characterClassManager = null;
 			ReferenceHub userHub = Extensions.Player.GetPlayer(user);
+			ReferenceHub issuerHub = Extensions.Player.GetPlayer(issuer);
 			try
 			{
 				if (ConfigFile.ServerConfig.GetBool("online_mode", false))
@@ -44,7 +45,7 @@ namespace EXILED.Patches
 			try
 			{
 				bool allow = true;
-				Events.InvokePlayerBan(ref userHub, ref userId, ref duration, ref allow, ref message, ref reason);
+				Events.InvokePlayerBan(ref userHub, ref userId, ref duration, ref allow, ref message, ref reason, ref issuerHub);
 
 				if (!allow)
 					return false;

--- a/EXILED_Events/Patches/BanUserOverride.cs
+++ b/EXILED_Events/Patches/BanUserOverride.cs
@@ -24,6 +24,7 @@ namespace EXILED.Patches
 			CharacterClassManager characterClassManager = null;
 			ReferenceHub userHub = Extensions.Player.GetPlayer(user);
 			ReferenceHub issuerHub = Extensions.Player.GetPlayer(issuer);
+			if (issuerHub == null) issuerHub = Extensions.Player.GetPlayer(PlayerManager.localPlayer);
 			try
 			{
 				if (ConfigFile.ServerConfig.GetBool("online_mode", false))

--- a/EXILED_Events/Patches/ElevatorInteractionEvent.cs
+++ b/EXILED_Events/Patches/ElevatorInteractionEvent.cs
@@ -7,7 +7,7 @@ namespace EXILED.Patches
     [HarmonyPatch(typeof(PlayerInteract), nameof(PlayerInteract.CallCmdUseElevator), typeof(GameObject))]
     public class ElevatorUseEvent
     {
-        public static bool Prefix(PlayerInteract _instance, GameObject elevator)
+        public static bool Prefix(PlayerInteract __instance, GameObject elevator)
         {
             if (EventPlugin.ElevatorInteractionEventDisable)
                 return true;
@@ -15,8 +15,8 @@ namespace EXILED.Patches
             try
             {
                 bool allow = true;
-                if (!_instance._playerInteractRateLimit.CanExecute(true) || 
-                    (_instance._hc.CufferId > 0 && !_instance.CanDisarmedInteract) || elevator == null) 
+                if (!__instance._playerInteractRateLimit.CanExecute(true) || 
+                    (__instance._hc.CufferId > 0 && !__instance.CanDisarmedInteract) || elevator == null) 
                     return false;
                     
                 Lift component = elevator.GetComponent<Lift>();
@@ -25,15 +25,15 @@ namespace EXILED.Patches
 
                 foreach (Lift.Elevator elevator2 in component.elevators)
                 {
-                    if (_instance.ChckDis(elevator2.door.transform.position))
+                    if (__instance.ChckDis(elevator2.door.transform.position))
                     {
-                        Events.InvokeElevatorInteract(_instance.gameObject, elevator2, ref allow);
+                        Events.InvokeElevatorInteract(__instance.gameObject, elevator2, ref allow);
 
                         if (!allow)
                             return false;
 
                         elevator.GetComponent<Lift>().UseLift();
-                        _instance.OnInteract();
+                        __instance.OnInteract();
                     }
                 }
 

--- a/EXILED_Idler/EXILED_Idler.csproj
+++ b/EXILED_Idler/EXILED_Idler.csproj
@@ -45,7 +45,7 @@
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
         <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>..\..\References\UnityEngine.CoreModule.dll</HintPath>
+          <HintPath>..\References\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- Fixed ElevatorInteractionEvent harmony instance typo ( _instance -> __instance )

- Deleted unused UnityEngine.Networking reference.

- Fixed UnityEngine.CoreModule hintpath in EXILED_Idler.csproj

- Added ReferenceHub Issuer in PlayerBanEvent