### PR TITLE
stop triggered RoundEnd at RoundStart and prevents error at RoundRestart

### DIFF
--- a/EXILED_Events/Patches/CheckRoundEndEvent.cs
+++ b/EXILED_Events/Patches/CheckRoundEndEvent.cs
@@ -39,6 +39,7 @@ namespace EXILED.Patches
 			{
 				while (RoundSummary.RoundLock || !RoundSummary.RoundInProgress() || PlayerManager.players.Count < 2)
 					yield return 0.0f;
+				yield return 0.0f;
 				RoundSummary.SumInfo_ClassList newList = new RoundSummary.SumInfo_ClassList();
 				foreach (GameObject player in PlayerManager.players)
 				{
@@ -139,6 +140,7 @@ namespace EXILED.Patches
 					for (i1 = (byte)0; i1 < (byte)50; ++i1)
 						yield return 0.0f;
 					PlayerManager.localPlayer.GetComponent<PlayerStats>().Roundrestart();
+					yield break;
 				}
 			}
 		}


### PR DESCRIPTION
prevents the following errors

```
NullReferenceException
  at (wrapper managed-to-native) UnityEngine.Component.GetComponentFastPath(UnityEngine.Component,System.Type,intptr)
  at UnityEngine.Component.GetComponent[T] () [0x00021] in <cebd4f081718416185e10e6a32ed95bf>:0 
  at Mirror.NetworkBehaviour.get_netIdentity () [0x0000e] in <1b0c0d2fb7eb4146b69a2a3af1f33755>:0 
  at Mirror.NetworkBehaviour.get_isServer () [0x00000] in <1b0c0d2fb7eb4146b69a2a3af1f33755>:0 
  at Mirror.NetworkBehaviour.SendRPCInternal (System.Type invokeClass, System.String rpcName, Mirror.NetworkWriter writer, System.Int32 channelId) [0x0001d] in <1b0c0d2fb7eb4146b69a2a3af1f33755>:0 
  at RoundSummary.RpcDimScreen () [0x00006] in <272e168a6a4543f19545eec349160d10>:0 
  at EXILED.Patches.CheckRoundEndEvent+<Process>d__2.MoveNext () [0x006f5] in <2933caa912d446a88614ebcd934fe22c>:0 
  at MEC.Timing.FixedUpdate () [0x000d1] in <dea0299a9e3c4160a9814e7cec5f7065>:0 
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
MEC.Timing:FixedUpdate()
 
(Filename: <cebd4f081718416185e10e6a32ed95bf> Line: 0)
```