### PR TITLE
MuteHandler fixes

### DIFF
--- a/EXILED_Events/Patches/PlayerJoinEvent.cs
+++ b/EXILED_Events/Patches/PlayerJoinEvent.cs
@@ -19,12 +19,13 @@ namespace EXILED.Patches
 
             try
             {
-                Timing.CallDelayed(0.25f, () => { 
-                    foreach(ReferenceHub player in Player.GetHubs())
-                    {
-                        if(player.characterClassManager.NetworkMuted)
-                            player.characterClassManager.SetDirtyBit(1ul);
-                    }
+                MuteHandler.Mutes.Clear();
+                MuteHandler.Reload();
+                Timing.CallDelayed(1f, () => {
+                    if (MuteHandler.QueryPersistantMute(__instance._ccm.UserId))
+                        __instance._ccm.SetMuted(true);
+                    else
+                        __instance._ccm.SetMuted(false);
                 });
 
                 ReferenceHub hub = __instance.gameObject.GetPlayer();


### PR DESCRIPTION
### MuteHandler is made by a pepega.

When MuteHandler reloads, it doesn't clear the Mutes HashSet when re-reading the mutes.txt meaning that people who are not in the file anymore will stay muted untill the whole server restarts.

Also changed that foreach loop to just checking the actual player who joins. Why even use a foreach loop?


This fix also allows hotswapping and editing the mutes.txt to work.
