### PR TITLE
fix PlayerSpawnEvent being fire twice

### DIFF
--- a/EXILED_Events/Patches/PlayerSpawnEvent.cs
+++ b/EXILED_Events/Patches/PlayerSpawnEvent.cs
@@ -1,6 +1,8 @@
 ﻿using Harmony;
 using Mirror;
 using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace EXILED.Patches
@@ -115,6 +117,21 @@ namespace EXILED.Patches
 			{
 				Log.Error($"PlayerSpawnEvent error: {exception}");
 				return true;
+			}
+		}
+	}
+
+	[HarmonyPatch(typeof(CharacterClassManager), "set_" + nameof(CharacterClassManager.NetworkCurClass))]
+	public static class PreventSpawnEventsPatch
+	{
+		public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+		{
+			bool isNOPDetected = false;
+			foreach(CodeInstruction instruction in instructions)
+			{
+				if(instruction.opcode == OpCodes.Nop) isNOPDetected = true;
+				if(!isNOPDetected) yield return new CodeInstruction(OpCodes.Nop);
+				else yield return instruction;
 			}
 		}
 	}


### PR DESCRIPTION
__CharacterClassManager.NetworkCurClass__
```cs
set
{
	if (NetworkServer.localClientActive && !base.getSyncVarHookGuard(8UL))
	{
		base.setSyncVarHookGuard(8UL, true);
		this.SetClassID(value);
		base.setSyncVarHookGuard(8UL, false);
	}
	base.SetSyncVar<RoleType>(value, ref this.CurClass, 8UL);
}
```
fix to ->
```cs
set
{
	base.SetSyncVar<RoleType>(value, ref this.CurClass, 8UL);
}
```