### PR TITLE
Remove OnReload when reloading all plugins

### DIFF
--- a/EXILED_Main/PluginManager.cs
+++ b/EXILED_Main/PluginManager.cs
@@ -223,7 +223,6 @@ namespace EXILED
 			{
 				Log.Info($"Reloading Plugins...");
 				OnDisable();
-				OnReload();
 				_plugins.Clear();
 
 				Timing.RunCoroutine(LoadPlugins());


### PR DESCRIPTION
Why reload *after* it's disabled *and* it's going to be re-enabled?