### PR TITLE
Sorting plugins by file name during loading and filtering by file extension

### DIFF
--- a/EXILED_Main/PluginManager.cs
+++ b/EXILED_Main/PluginManager.cs
@@ -43,7 +43,10 @@ namespace EXILED
 				Directory.CreateDirectory(path);
 			}
 
-			List<string> mods = Directory.GetFiles(path).Where(p => !p.EndsWith("overrides.txt")).ToList();
+			var files = Directory.GetFiles(path);
+			Array.Sort(files, string.Compare);
+
+			List<string> mods = files.Where(p => p.EndsWith(".dll")).ToList();
 
 			if (File.Exists($"{path}/overrides.txt"))
 				_typeOverrides = File.ReadAllText($"{path}/overrides.txt");


### PR DESCRIPTION
Sorting the plugins by name will help to set priority in some cases.
Filtering by file extension may also be needed if, for example, you do not want to load a plugin called "AnotherPlugin.dll.off".