### PR TITLE
Ability to turn off the drop of inventory

### DIFF
--- a/EXILED_Events/EventHandlers.cs
+++ b/EXILED_Events/EventHandlers.cs
@@ -92,7 +92,9 @@ namespace EXILED.Patches
 				if (!EventPlugin.DeadPlayers.Contains(ev.Player))
 					EventPlugin.DeadPlayers.Add(ev.Player);
 
-				ev.Player.inventory.ServerDropAll();
+				if (EventPlugin.DropInventory) {
+					ev.Player.inventory.ServerDropAll();
+				}
 			}
 			else
 			{

--- a/EXILED_Events/Plugin.cs
+++ b/EXILED_Events/Plugin.cs
@@ -84,6 +84,7 @@ namespace EXILED
 		public static bool Scp173Fix;
 		public static bool Scp096Fix;
 		public static bool NameTracking;
+		public static bool DropInventory;
 		public static Dictionary<ReferenceHub, List<int>> TargetGhost = new Dictionary<ReferenceHub, List<int>>();
 		public static List<ReferenceHub> DeadPlayers = new List<ReferenceHub>();
 
@@ -136,6 +137,7 @@ namespace EXILED
 			Scp173Fix = Config.GetBool("exiled_tut_fix173", true);
 			Scp096Fix = Config.GetBool("exiled_tut_fix096", true);
 			NameTracking = Config.GetBool("exiled_name_tracking", true);
+			DropInventory = Config.GetBool("exiled_drop_inventory", true);
 		}
 
 		private void AutoUpdate()

--- a/EXILED_Main/EXILED_Main.csproj
+++ b/EXILED_Main/EXILED_Main.csproj
@@ -50,16 +50,16 @@
       <HintPath>..\References\Mono.Security.dll</HintPath>
     </Reference>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\References\netstandard.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\netstandard.dll</HintPath>
     </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\References\System.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\References\System.Configuration.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\References\System.Core.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.StackTrace, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -69,13 +69,13 @@
       <HintPath>..\References\System.Globalization.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\References\System.IO.Compression.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.IO.Compression.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\References\System.Runtime.Serialization.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.Runtime.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\References\System.Xml.dll</HintPath>
+      <HintPath>..\..\..\joker\dlls\System.Xml.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\References\UnityEngine.dll</HintPath>
@@ -89,7 +89,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiObjects\AmmoType.cs" />
-    <Compile Include="ApiObjects\GlobalBadge.cs" />
     <Compile Include="ApiObjects\Room.cs" />
     <Compile Include="ApiObjects\ZoneType.cs" />
     <Compile Include="Attributes\SkipAutoHarmonyAttribute.cs" />

--- a/EXILED_Main/EXILED_Main.csproj
+++ b/EXILED_Main/EXILED_Main.csproj
@@ -50,16 +50,16 @@
       <HintPath>..\References\Mono.Security.dll</HintPath>
     </Reference>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\..\..\joker\dlls\netstandard.dll</HintPath>
+      <HintPath>..\References\netstandard.dll</HintPath>
     </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\..\..\joker\dlls\System.dll</HintPath>
+      <HintPath>..\References\System.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\..\joker\dlls\System.Configuration.dll</HintPath>
+      <HintPath>..\References\System.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\..\..\joker\dlls\System.Core.dll</HintPath>
+      <HintPath>..\References\System.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.StackTrace, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -69,13 +69,13 @@
       <HintPath>..\References\System.Globalization.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\..\..\joker\dlls\System.IO.Compression.dll</HintPath>
+      <HintPath>..\References\System.IO.Compression.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\..\..\joker\dlls\System.Runtime.Serialization.dll</HintPath>
+      <HintPath>..\References\System.Runtime.Serialization.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>..\..\..\joker\dlls\System.Xml.dll</HintPath>
+      <HintPath>..\References\System.Xml.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\References\UnityEngine.dll</HintPath>
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiObjects\AmmoType.cs" />
+    <Compile Include="ApiObjects\GlobalBadge.cs" />
     <Compile Include="ApiObjects\Room.cs" />
     <Compile Include="ApiObjects\ZoneType.cs" />
     <Compile Include="Attributes\SkipAutoHarmonyAttribute.cs" />


### PR DESCRIPTION
Adds the "exiled_drop_inventory" setting that allows to disable throwing items out of the inventory when the class changes to spectator/player leaves the game.