### PR TITLE
Tied coroutines to GameObjects instead of a globally shared tag.

### DIFF
--- a/EXILED_Events/Components/AntiAimbot.cs
+++ b/EXILED_Events/Components/AntiAimbot.cs
@@ -37,8 +37,7 @@ namespace EXILED.Components
 				NetworkServer.Spawn(obj);
 				sync = obj.GetComponent<PlyMovementSync>();
 				ident = obj.GetComponent<NetworkIdentity>();
-
-				Timing.RunCoroutine(Thing(), "thing");
+				MEC.Timing.RunCoroutine(Thing(), this.gameObject);
 			}
 			catch (Exception e)
 			{
@@ -48,7 +47,7 @@ namespace EXILED.Components
 
 		public void OnDestroy()
 		{
-			Timing.KillCoroutines("thing");
+			Timing.KillCoroutines(this.gameObject);
 		}
 
 		public IEnumerator<float> Thing()


### PR DESCRIPTION
Fixes a single disconnect disabling the Anti-Aimbot for every single connected player in the match (only players that joined after them would have the coroutine), and adds some sweetness of MEC's magic.