### PR TITLE
Made preauth event useful

### DIFF
--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -4,7 +4,9 @@ using Scp914;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using LiteNetLib.Utils;
 using UnityEngine;
+using ZXing;
 using static BanHandler;
 
 namespace EXILED
@@ -138,9 +140,78 @@ namespace EXILED
 
 	public class PreauthEvent : EventArgs
 	{
-		public string UserId { get; set; }
-		public ConnectionRequest Request { get; set; }
-		public bool Allow { get; set; }
+		public PreauthEvent(string UserId, ConnectionRequest request, int position, byte flags, string country)
+		{
+			this.UserId = UserId;
+			Request = request;
+			ReaderStartPosition = position;
+			Flags = flags;
+			Country = country;
+		}
+
+		public readonly string UserId;
+		public readonly int ReaderStartPosition;
+		public readonly byte Flags;
+		public readonly string Country;
+		public readonly ConnectionRequest Request;
+
+		private bool _allow = true;
+		
+		public bool Allow
+		{
+			get => _allow;
+			set
+			{
+				if (value) throw new Exception("It's not possible to change this variable to true.");
+				_allow = false;
+			}
+		}
+
+		public void Disallow() => _allow = false;
+
+		public void Reject(RejectionReason reason) => InternalReject(reason);
+
+		public void Reject(string reason)
+		{
+			if (reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
+			InternalReject(RejectionReason.Custom, reason);
+		}
+		
+		public void Reject(NetDataWriter writer)
+		{
+			if (!Allow) return;
+			Allow = false;
+			Request.Reject(writer);
+		}
+		
+		public void RejectForce(RejectionReason reason) => InternalReject(reason, null, true);
+
+		public void RejectForce(string reason)
+		{
+			if (reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
+			InternalReject(RejectionReason.Custom, reason, true);
+		}
+		
+		public void RejectForce(NetDataWriter writer)
+		{
+			if (!Allow) return;
+			Allow = false;
+			Request.RejectForce(writer);
+		}
+
+		private void InternalReject(RejectionReason reason, string customReason = null, bool force = false)
+		{
+			if (!Allow) return;
+			Allow = false;
+			NetDataWriter rejectData = new NetDataWriter();
+			rejectData.Put((byte)reason);
+			if (reason == RejectionReason.Custom)
+				rejectData.Put(customReason);
+			
+			if (force)
+				Request.RejectForce(rejectData);
+			else Request.Reject(rejectData);
+		}
 	}
 
 	public class RACommandEvent : EventArgs

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -172,7 +172,7 @@ namespace EXILED
 
 		public void Reject(string reason)
 		{
-			if (reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
+			if (reason != null && reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
 			InternalReject(RejectionReason.Custom, reason);
 		}
 		
@@ -187,7 +187,7 @@ namespace EXILED
 
 		public void RejectForce(string reason)
 		{
-			if (reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
+			if (reason != null && reason.Length > 400) throw new Exception("Reason can't be longer than 400 characters.");
 			InternalReject(RejectionReason.Custom, reason, true);
 		}
 		

--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using LiteNetLib.Utils;
 using UnityEngine;
-using ZXing;
 using static BanHandler;
 
 namespace EXILED

--- a/EXILED_Events/Events/ServerEvents.cs
+++ b/EXILED_Events/Events/ServerEvents.cs
@@ -20,22 +20,16 @@ namespace EXILED
 		public static event OnPreAuth PreAuthEvent;
 		public delegate void OnPreAuth(ref PreauthEvent ev);
 
-		public static void InvokePreAuth(ref string userId, ConnectionRequest request, ref bool allow)
+		public static void InvokePreAuth(string userId, ConnectionRequest request, int position, byte flags, string country, ref bool allow)
 		{
 			if (PreAuthEvent == null)
 				return;
 
-			PreauthEvent ev = new PreauthEvent()
-			{
-				Allow = allow,
-				Request = request,
-				UserId = userId
-			};
+			PreauthEvent ev = new PreauthEvent(userId, request, position, flags, country);
 
 			PreAuthEvent.Invoke(ref ev);
 
 			allow = ev.Allow;
-			userId = ev.UserId;
 		}
 
 		public static event OnRoundEnd RoundEndEvent;

--- a/EXILED_Events/Patches/PreAuthEvent.cs
+++ b/EXILED_Events/Patches/PreAuthEvent.cs
@@ -35,6 +35,7 @@ namespace EXILED.Patches
 			{
 				byte result1;
 				byte result2;
+				int position = request.Data.Position;
 				if (!request.Data.TryGetByte(out result1) || !request.Data.TryGetByte(out result2) || result1 != CustomNetworkManager.Major || result2 != CustomNetworkManager.Minor)
 				{
 					rejectData.Reset();
@@ -180,12 +181,17 @@ namespace EXILED.Patches
 												else
 													CustomLiteNetLib4MirrorTransport.UserIds.Add(request.RemoteEndPoint, new PreauthItem(result3));
 												bool allow = true;
-												Events.InvokePreAuth(ref result3, request, ref allow);
+												Events.InvokePreAuth(result3, request, position, result5, result6, ref allow);
 												if (allow)
 												{
 													request.Accept();
 													ServerConsole.AddLog(string.Format("Player {0} preauthenticated from endpoint {1}.", result3, request.RemoteEndPoint));
 													ServerLogs.AddLog(ServerLogs.Modules.Networking, string.Format("{0} preauthenticated from endpoint {1}.", result3, request.RemoteEndPoint), ServerLogs.ServerLogType.ConnectionUpdate);
+												}
+												else
+												{
+													ServerConsole.AddLog(string.Format("Player {0} tried to preauthenticate from endpoint {1}, but the request has been rejected by a plugin.", result3, request.RemoteEndPoint));
+													ServerLogs.AddLog(ServerLogs.Modules.Networking, string.Format("{0} tried to preauthenticate from endpoint {1}, but the request has been rejected by a plugin.", result3, request.RemoteEndPoint), ServerLogs.ServerLogType.ConnectionUpdate);
 												}
 											}
 											else


### PR DESCRIPTION
Currently usage of preauth event is almost impossible - rejecting a connection requires using NetDataWriter and writing rejection reasons codes and most of the developers doesn't know how to use it and reading anything else than UserId was even harder.

I made UserID variable readonly, because changing it here will cause an authentication issue in the primary auth and it can potentially cause an unwanted plugins interference (plugin can receive different UserID in preauth and join events, because another plugin has changed it here).