### PR TITLE
Make PlayerReloadEvent usable

### DIFF
--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -552,6 +552,7 @@ namespace EXILED
 	{
 		public ReferenceHub Player { get; set; }
 		public bool Allow { get; set; }
+		public bool AnimationOnly { get; internal set; }
 	}
 
 	public class PlayerSpawnEvent : EventArgs

--- a/EXILED_Events/Events/PlayerEvents.cs
+++ b/EXILED_Events/Events/PlayerEvents.cs
@@ -712,7 +712,7 @@ namespace EXILED
 		public static event PlayerReload PlayerReloadEvent;
 		public delegate void PlayerReload(ref PlayerReloadEvent ev);
 
-		public static void InvokePlayerReload(GameObject player, ref bool allow)
+		public static void InvokePlayerReload(GameObject player, ref bool allow, bool animationOnly)
 		{
 			if (PlayerReloadEvent == null)
 				return;
@@ -720,7 +720,8 @@ namespace EXILED
 			PlayerReloadEvent ev = new PlayerReloadEvent
 			{
 				Player = player.GetPlayer(),
-				Allow = allow
+				Allow = allow,
+				AnimationOnly = animationOnly
 			};
 
 			PlayerReloadEvent.Invoke(ref ev);

--- a/EXILED_Events/Patches/PlayerReloadEvent.cs
+++ b/EXILED_Events/Patches/PlayerReloadEvent.cs
@@ -23,7 +23,7 @@ namespace EXILED.Patches
 
 				bool allow = true;
 
-				Events.InvokePlayerReload(__instance.gameObject, ref allow);
+				Events.InvokePlayerReload(__instance.gameObject, ref allow, animationOnly);
 
 				return allow;
 			}


### PR DESCRIPTION
Now PlayerReloadEvent is called twice, on animation start and on reload finish, this PR allows plugin to know which is it