### PR TITLE
Add way to get players badge easier, Checks for players being NTF added

### DIFF
--- a/EXILED_Main/Extensions/Item.cs
+++ b/EXILED_Main/Extensions/Item.cs
@@ -76,7 +76,7 @@ namespace EXILED.Extensions {
             || ItemType.KeycardScientistMajor == type || ItemType.KeycardSeniorGuard == type || ItemType.KeycardZoneManager == type;
         
         /// <summary>
-        /// Check if an <see cref="ItemType">picked up or dropped item</see> is a gun.
+        /// Check if an <see cref="Pickup">picked up or dropped item</see> is a gun.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>

--- a/EXILED_Main/Extensions/Item.cs
+++ b/EXILED_Main/Extensions/Item.cs
@@ -74,6 +74,25 @@ namespace EXILED.Extensions {
             || ItemType.KeycardGuard == type || ItemType.KeycardJanitor == type || ItemType.KeycardNTFCommander == type
             || ItemType.KeycardNTFLieutenant == type || ItemType.KeycardO5 == type || ItemType.KeycardScientist == type
             || ItemType.KeycardScientistMajor == type || ItemType.KeycardSeniorGuard == type || ItemType.KeycardZoneManager == type;
-
+        
+        /// <summary>
+        /// Check if an <see cref="ItemType">picked up or dropped item</see> is a gun.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public static bool IsGun(this Pickup item)
+        {
+            switch (item.ItemId) {
+                case ItemType.GunCOM15:
+                case ItemType.GunE11SR:
+                case ItemType.GunLogicer:
+                case ItemType.GunMP7:
+                case ItemType.GunProject90:
+                case ItemType.GunUSP:
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/EXILED_Main/Extensions/Item.cs
+++ b/EXILED_Main/Extensions/Item.cs
@@ -27,10 +27,10 @@ namespace EXILED.Extensions {
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
-        public static bool IsWeapon( this ItemType type ) =>
+        public static bool IsWeapon( this ItemType type , bool checkMicro) =>
             type == ItemType.GunCOM15 || type == ItemType.GunE11SR || type == ItemType.GunLogicer
             || type == ItemType.GunMP7 || type == ItemType.GunProject90 || type == ItemType.GunUSP
-            || type == ItemType.MicroHID;
+            || (checkMicro && type == ItemType.MicroHID);
 
         /// <summary>
         /// Check if an <see cref="ItemType">item</see> is a SCP item.
@@ -74,25 +74,5 @@ namespace EXILED.Extensions {
             || ItemType.KeycardGuard == type || ItemType.KeycardJanitor == type || ItemType.KeycardNTFCommander == type
             || ItemType.KeycardNTFLieutenant == type || ItemType.KeycardO5 == type || ItemType.KeycardScientist == type
             || ItemType.KeycardScientistMajor == type || ItemType.KeycardSeniorGuard == type || ItemType.KeycardZoneManager == type;
-        
-        /// <summary>
-        /// Check if an <see cref="Pickup">picked up or dropped item</see> is a gun.
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        public static bool IsGun(this Pickup item)
-        {
-            switch (item.ItemId) {
-                case ItemType.GunCOM15:
-                case ItemType.GunE11SR:
-                case ItemType.GunLogicer:
-                case ItemType.GunMP7:
-                case ItemType.GunProject90:
-                case ItemType.GunUSP:
-                    return true;
-                default:
-                    return false;
-            }
-        }
     }
 }

--- a/EXILED_Main/Extensions/Item.cs
+++ b/EXILED_Main/Extensions/Item.cs
@@ -33,7 +33,7 @@ namespace EXILED.Extensions
         /// <returns></returns>
 
         public static bool IsWeapon( this ItemType type , bool checkMicro) =>
-        type == ItemType.GunCOM15 || type == ItemType.GunE11SR || type == ItemType.GunLogicer
+            type == ItemType.GunCOM15 || type == ItemType.GunE11SR || type == ItemType.GunLogicer
             || type == ItemType.GunMP7 || type == ItemType.GunProject90 || type == ItemType.GunUSP
             || (checkMicro && type == ItemType.MicroHID);
 

--- a/EXILED_Main/Extensions/Player.cs
+++ b/EXILED_Main/Extensions/Player.cs
@@ -95,6 +95,13 @@ namespace EXILED.Extensions
 		public static bool IsScp(this ReferenceHub hub) => hub.characterClassManager.IsAnyScp();
 		
 		/// <summary>
+		/// Checks if a player's role type is any NTF type <see cref="ReferenceHub"/>.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+       		public static bool IsNTF(this ReferenceHub hub) => hub.GetRole() == RoleType.NtfCadet || hub.GetRole() == RoleType.NtfScientist || hub.GetRole() == RoleType.NtfLieutenant || hub.GetRole() == RoleType.NtfCommander;
+		
+		/// <summary>
 		/// Gets a player's Current Role.
 		/// </summary>
 		/// <param name="player">Player</param>

--- a/EXILED_Main/Extensions/Player.cs
+++ b/EXILED_Main/Extensions/Player.cs
@@ -953,5 +953,12 @@ namespace EXILED.Extensions
 		/// <param name="value"></param>
 		public static void SetFriendlyFire(this ReferenceHub player, bool value) =>
 			player.weaponManager.NetworkfriendlyFire = value;
+		
+		/// <summary>
+		/// Gets the badge name of a <see cref="ReferenceHub"/>.
+		/// </summary>
+		/// <param name="player"></param>
+		/// <returns></returns>
+        	public static string GetBadgeName(this ReferenceHub rh) => rh.serverRoles.Group.BadgeText;
 	}
 }

--- a/EXILED_Main/Extensions/Player.cs
+++ b/EXILED_Main/Extensions/Player.cs
@@ -99,7 +99,19 @@ namespace EXILED.Extensions
 		/// </summary>
 		/// <param name="player"></param>
 		/// <returns></returns>
-       		public static bool IsNTF(this ReferenceHub hub) => hub.GetRole() == RoleType.NtfCadet || hub.GetRole() == RoleType.NtfScientist || hub.GetRole() == RoleType.NtfLieutenant || hub.GetRole() == RoleType.NtfCommander;
+       		public static bool IsNTF(this ReferenceHub hub)
+        	{
+            		switch (hub.GetRole())
+            		{
+                		case RoleType.NtfCadet:
+                		case RoleType.NtfScientist:
+                		case RoleType.NtfLieutenant:
+                		case RoleType.NtfCommander:
+                    			return true;
+                		default:
+                    			return false;
+            		}
+        	}
 		
 		/// <summary>
 		/// Gets a player's Current Role.


### PR DESCRIPTION
An extension to ReferenceHub that will get the badge they have on. Instead of doing ReferenceHub.GetRank().BadgeText, they can just do ReferenceHub.GetBadgeName() to simplify it some more