### PR TITLE
Make ItemDroppedEvent more usable

### DIFF
--- a/EXILED_Events/Events/EventArgs.cs
+++ b/EXILED_Events/Events/EventArgs.cs
@@ -299,6 +299,7 @@ namespace EXILED
 	{
 		public ReferenceHub Player;
 		public Pickup Item;
+		public Inventory.SyncItemInfo SyncItemInfo { get; set; }
 	}
 
 	public class PickupItemEvent : EventArgs

--- a/EXILED_Events/Events/PlayerEvents.cs
+++ b/EXILED_Events/Events/PlayerEvents.cs
@@ -437,7 +437,7 @@ namespace EXILED
 		public static event ItemDropped ItemDroppedEvent;
 		public delegate void ItemDropped(ItemDroppedEvent ev);
 
-		public static void InvokeItemDropped(GameObject player, Pickup pickup)
+		public static void InvokeItemDropped(GameObject player, Pickup pickup, Inventory.SyncItemInfo syncItemInfo)
 		{
 			if (ItemDroppedEvent == null)
 				return;
@@ -446,6 +446,7 @@ namespace EXILED
 			{
 				Player = player.GetPlayer(),
 				Item = pickup,
+				SyncItemInfo = syncItemInfo
 			};
 
 			ItemDroppedEvent.Invoke(ev);

--- a/EXILED_Events/Patches/DropItemEvent.cs
+++ b/EXILED_Events/Patches/DropItemEvent.cs
@@ -34,7 +34,7 @@ namespace EXILED.Patches
 
 				__instance.items.RemoveAt(itemInventoryIndex);
 
-				Events.InvokeItemDropped(__instance.gameObject, dropped);
+				Events.InvokeItemDropped(__instance.gameObject, dropped, syncItemInfo);
 
 				return false;
 			}


### PR DESCRIPTION
Title.
Also please change current `Item` to `Pickup` and `SyncItemInfo` to `Item` in `DropItemEvent` on 2.0, it's confusing now.