### PR TITLE
Fixed PlayerDeathEvent not triggered with NUKE damage

### DIFF
--- a/EXILED_Events/Patches/PlayerHurtEvent.cs
+++ b/EXILED_Events/Patches/PlayerHurtEvent.cs
@@ -37,7 +37,7 @@ namespace EXILED.Patches
 				else
 					Events.InvokePlayerHurt(__instance, ref info, go);
 
-				if (info.Amount >= go.GetComponent<PlayerStats>().health || (go.GetComponent<PlayerStats>().health - info.Amount) <= 1f)
+				if (info.Amount < 0 || info.Amount >= go.GetComponent<PlayerStats>().health || (go.GetComponent<PlayerStats>().health - info.Amount) <= 1f)
 				{
 					CharacterClassManager ccm = go.GetComponent<CharacterClassManager>();
 


### PR DESCRIPTION
Nuke will now trigger PlayerDeadEvent