### PR TITLE
Detailed information about the exception

### DIFF
--- a/EXILED_Events/EXILED_Events.csproj
+++ b/EXILED_Events/EXILED_Events.csproj
@@ -11,9 +11,9 @@
     <AssemblyName>EXILED_Events</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +25,6 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>/home/Joker/Projects/SCP Plugins/bin/EXILED</OutputPath>
@@ -135,7 +134,7 @@
     <Folder Include="Components\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>

--- a/EXILED_Events/Extensions/EventExtensions.cs
+++ b/EXILED_Events/Extensions/EventExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Reflection;
 
 namespace EXILED.Extensions
@@ -17,7 +16,7 @@ namespace EXILED.Extensions
 
             foreach (var handler in action.GetInvocationList())
             {
-                HandleSafely(action.GetType().FullName, handler.Method, handler.Target,  args);
+                HandleSafely(action.GetType().FullName, handler.Method, handler.Target, args);
             }
         }
 

--- a/EXILED_Events/Extensions/EventExtensions.cs
+++ b/EXILED_Events/Extensions/EventExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 
 namespace EXILED.Extensions
@@ -16,7 +17,7 @@ namespace EXILED.Extensions
 
             foreach (var handler in action.GetInvocationList())
             {
-                HandleSafely(handler.Method, handler.Target,  args);
+                HandleSafely(action.GetType().FullName, handler.Method, handler.Target,  args);
             }
         }
 
@@ -27,7 +28,7 @@ namespace EXILED.Extensions
         ///     Instance of the delegate method object,
         ///     null is used in the case of a static method.
         /// </param>
-        private static void HandleSafely(MethodInfo action, object instance, params object[] args)
+        private static void HandleSafely(string eventName, MethodInfo action, object instance, params object[] args)
         {
             try
             {
@@ -35,7 +36,8 @@ namespace EXILED.Extensions
             }
             catch (Exception ex)
             {
-                Log.Error($"Plugin: {instance} Caused an error when processing the event {action}: {ex.InnerException} {ex.Message}");
+                // instance is null for static methods, we shouldn't use it
+                Log.Error($"Method '{action.Name}' of the class '{action.ReflectedType.FullName}' caused an error when processing the event '{eventName}': {ex.InnerException} {ex.Message}");
                 Log.Error(ex.StackTrace);
             }
         }

--- a/EXILED_Permissions/EXILED_Permissions.csproj
+++ b/EXILED_Permissions/EXILED_Permissions.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Content:
- More information about an exception caused by a plugin that passed through `InvokeSafely`, now it is possible to look at the source with a static method.
- Correct compilation on the x64 platform for all projects, I didn't include Exiled_Idler because it will be deleted soon.