### PR TITLE
oops negative scps

### DIFF
--- a/Exiled.Events/Patches/Events/Server/RoundEnd.cs
+++ b/Exiled.Events/Patches/Events/Server/RoundEnd.cs
@@ -134,6 +134,8 @@ namespace Exiled.Events.Patches.Events.Server
 
                     if (roundSummary != null)
                     {
+                        newList.scps_except_zombies -= newList.zombies;
+                        
                         var roundEndedEventArgs = new RoundEndedEventArgs(endingRoundEventArgs.LeadingTeam, newList, timeToRoundRestart);
 
                         Server.OnRoundEnded(roundEndedEventArgs);


### PR DESCRIPTION
Apparently this bug still exists so I removed it. Zombies will not cause the negative scp bug because they are not real scps.