### PR TITLE
feat: Sweet exceptions

### DIFF
--- a/EXILED_Events/Extensions/EventExtensions.cs
+++ b/EXILED_Events/Extensions/EventExtensions.cs
@@ -1,10 +1,15 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace EXILED.Extensions
 {
     public static class EventExtensions
     {
+        // end of call stack inner exceptions
+        const string endOfInnerExceptionStack = "--- End of inner exception stack trace ---";
+        readonly static string endOfInnerExcetionFinalTemplate = $"{Environment.NewLine}   ---> {{0}}{Environment.NewLine}{{1}}";
+
         /// <summary>
         ///     Executes all delegate listeners safely.
         /// </summary>
@@ -14,31 +19,87 @@ namespace EXILED.Extensions
             if (action == null)
                 return;
 
+            var eventName = action.GetType().FullName;
             foreach (var handler in action.GetInvocationList())
             {
-                HandleSafely(action.GetType().FullName, handler.Method, handler.Target, args);
+                HandleSafely(eventName, handler, args);
             }
         }
 
         /// <summary>
         ///     Executes <see cref="MethodInfo"/> safely.
         /// </summary>
-        /// <param name="instance">
-        ///     Instance of the delegate method object,
-        ///     null is used in the case of a static method.
-        /// </param>
-        private static void HandleSafely(string eventName, MethodInfo action, object instance, params object[] args)
+        private static void HandleSafely(string eventName, Delegate @delegate, params object[] args)
         {
             try
-            {
-                action.Invoke(instance, args);
-            }
+            { @delegate.DynamicInvoke(args); }
             catch (Exception ex)
             {
-                // instance is null for static methods, we shouldn't use it
-                Log.Error($"Method '{action.Name}' of the class '{action.ReflectedType.FullName}' caused an error when processing the event '{eventName}': {ex.InnerException} {ex.Message}");
-                Log.Error(ex.StackTrace);
+                Log.Error($"Method '{@delegate.Method.Name}' of the class '{@delegate.Method.ReflectedType.FullName}' caused an error when processing the event '{eventName}': {GetExceptionMessage(ex)}");
+                // skip five frames
+                // 1. System.Reflection.MonoMethod.Invoke
+                // 2. System.Reflection.MethodBase.Invoke
+                // 3. System.Delegate.DynamicInvokeImpl
+                // 4. System.MulticastDelegate.DynamicInvokeImpl
+                // 5. Delegate.DynamicInvoke
+                var result = GetStackTrace(ex, 5, allowRecursion: false);
+                // skip two frames below
+                // 1. System.Reflection.MonoMethod.Invoke
+                // 2. System.Reflection.MonoMethod.InternalInvoke
+                var second = GetStackTrace(ex.InnerException, 2, false);
+                if (second != null)
+                    result += string.Format(endOfInnerExcetionFinalTemplate, second, endOfInnerExceptionStack);
+                // insert a new line for a better view of the stack
+                Log.Error(Environment.NewLine + result);
             }
+        }
+
+        // Just logs an exception without a call stack
+        // Literally a copy of `Exception.ToString()` from MSReference/Mono
+        private static string GetExceptionMessage(Exception ex)
+        {
+            var s = $"{ex.GetType()}: {ex.Message}";
+            if (ex.InnerException != null)
+            {
+                // just show the end of the inner exception
+                const string endOfInnerException = "--- End of inner exception ---";
+                s += string.Format(endOfInnerExcetionFinalTemplate, GetExceptionMessage(ex.InnerException), endOfInnerException);
+            }
+            return s;
+        }
+
+        readonly static FieldInfo stackTrace_frames = typeof(StackTrace).GetField("frames", BindingFlags.NonPublic | BindingFlags.Instance);
+        // skips multiple frames and returns the source stack
+        private static void StackTraceSkipFrames(StackTrace source, uint frameCount, bool above = true)
+        {
+            if (frameCount == 0)
+                return;
+
+            var sourceArray = (StackFrame[])stackTrace_frames.GetValue(source);
+            var finalSize = sourceArray.Length - frameCount;
+            if (finalSize > 0)
+            {
+                // I think the best option would not be to rewrite the parser,
+                // but simply change the array that contains the frames
+                if (above) Array.Reverse(sourceArray);
+                Array.Resize(ref sourceArray, Convert.ToInt32(finalSize));
+                stackTrace_frames.SetValue(source, sourceArray);
+                if (above) Array.Reverse(sourceArray);
+            }
+        }
+
+        // gets stacktrace from exception
+        private static string GetStackTrace(Exception ex, uint skipFrames, bool above = true, bool allowRecursion = true)
+        {
+            if (ex == null)
+                return null;
+
+            var stacktrace = new StackTrace(ex);
+            StackTraceSkipFrames(stacktrace, skipFrames, above);
+            var result = stacktrace.ToString();
+            if (allowRecursion && ex.InnerException != null)
+                result += string.Format(endOfInnerExcetionFinalTemplate, GetStackTrace(ex.InnerException, 0), endOfInnerExceptionStack);
+            return result;
         }
     }
 }

--- a/EXILED_Events/Extensions/EventExtensions.cs
+++ b/EXILED_Events/Extensions/EventExtensions.cs
@@ -48,7 +48,8 @@ namespace EXILED.Extensions
                 // 2. System.Reflection.MonoMethod.InternalInvoke
                 var second = GetStackTrace(ex.InnerException, 2, false);
                 if (second != null)
-                    result += string.Format(endOfInnerExcetionFinalTemplate, second, endOfInnerExceptionStack);
+                    // change the order of exceptions according to the call stack
+                    result = second + string.Format(endOfInnerExcetionFinalTemplate, result, endOfInnerExceptionStack);
                 // insert a new line for a better view of the stack
                 Log.Error(Environment.NewLine + result);
             }


### PR DESCRIPTION
I changed the exception view, now these look more beautiful than before.
Before:
```
[2020-07-03 14:47:25.155 -07:00] [ERROR] [EXILED_Events] Method 'OnRACommand' of the class 'SerpentsHand.EventHandlers' caused an error when processing the event 'EXILED.Events+OnCommand': System.MissingMethodException: void EXILED.Extensions.Player.Broadcast(ReferenceHub,uint,string,bool)
  at SerpentsHand.EventHandlers.CreateSquad (System.Int32 size) [0x00078] in <fc9f27b2c4df4c6fb5efe52ec34d4267>:0
  at SerpentsHand.EventHandlers.OnRACommand (EXILED.RACommandEvent& ev) [0x00117] in <fc9f27b2c4df4c6fb5efe52ec34d4267>:0
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <437ba245d8404784b9fbab9b439ac908>:0  Exception has been thrown by the target of an invocation.
  
[2020-07-03 14:47:25.195 -07:00] [ERROR] [EXILED_Events]   at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00048] in <437ba245d8404784b9fbab9b439ac908>:0
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <437ba245d8404784b9fbab9b439ac908>:0
  at EXILED.Extensions.EventExtensions.HandleSafely (System.String eventName, System.Reflection.MethodInfo action, System.Object instance, System.Object[] args) [0x00000] in <6a473b84e80f48a99673552de73a3c01>:0
```
After: ![](https://i.imgur.com/PSRRDCk.png)