### PR TITLE
Get rid of ArgumentNullException on null event calls

### DIFF
--- a/Exiled.Events/Extensions/Event.cs
+++ b/Exiled.Events/Extensions/Event.cs
@@ -26,9 +26,8 @@ namespace Exiled.Events.Extensions
         public static void InvokeSafely<T>(this Events.CustomEventHandler<T> ev, T arg)
             where T : EventArgs
         {
-            // So we'll see the exact reason
-            if (ev == null || arg == null)
-                throw new ArgumentNullException(ev == null ? nameof(ev) : nameof(arg));
+            if (ev == null)
+                return;
 
             var eventName = ev.GetType().FullName;
             foreach (Events.CustomEventHandler<T> handler in ev.GetInvocationList())


### PR DESCRIPTION
Since none of the events are protected during null calls, just return a value instead of throwing an exception.