### PR TITLE
Revise the Map & Room API

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
 
     using LightContainmentZoneDecontamination;
@@ -21,10 +22,15 @@ namespace Exiled.API.Features
     /// </summary>
     public static class Map
     {
-        private static List<Room> rooms = new List<Room>();
-        private static List<Door> doors = new List<Door>();
-        private static List<Lift> lifts = new List<Lift>();
-        private static List<TeslaGate> teslas = new List<TeslaGate>();
+        private static readonly List<Room> RoomsValue = new List<Room>();
+        private static readonly List<Door> DoorsValue = new List<Door>();
+        private static readonly List<Lift> LiftsValue = new List<Lift>();
+        private static readonly List<TeslaGate> TeslasValue = new List<TeslaGate>();
+
+        private static readonly ReadOnlyCollection<Room> ReadOnlyRoomsValue = RoomsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<Door> ReadOnlyDoorsValue = DoorsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<Lift> ReadOnlyLiftsValue = LiftsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<TeslaGate> ReadOnlyTeslasValue = TeslasValue.AsReadOnly();
 
         /// <summary>
         /// Gets a value indicating whether the decontamination has been completed or not.
@@ -44,56 +50,68 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets all <see cref="Room"/>.
         /// </summary>
-        public static List<Room> Rooms
+        public static ReadOnlyCollection<Room> Rooms
         {
             get
             {
-                if (rooms == null || rooms.Count == 0 || rooms.Any(r => r.Transform == null))
-                    rooms = Object.FindObjectsOfType<Transform>().Where(t => t.CompareTag("Room")).Select(rTranform => new Room(rTranform.name, rTranform, rTranform.position)).ToList();
+                if (RoomsValue.Count == 0 || RoomsValue.Any(r => r.Transform == null))
+                {
+                    RoomsValue.Clear();
+                    RoomsValue.AddRange(GameObject.FindGameObjectsWithTag("Room").Select(r => new Room(r.name, r.transform, r.transform.position)));
+                }
 
-                return rooms;
+                return ReadOnlyRoomsValue;
             }
         }
 
         /// <summary>
         /// Gets all <see cref="Door"/>.
         /// </summary>
-        public static List<Door> Doors
+        public static ReadOnlyCollection<Door> Doors
         {
             get
             {
-                if (doors == null || doors.Count == 0)
-                    doors = Object.FindObjectsOfType<Door>().ToList();
+                if (DoorsValue.Count == 0 || DoorsValue.Contains(null))
+                {
+                    DoorsValue.Clear();
+                    DoorsValue.AddRange(Object.FindObjectsOfType<Door>());
+                }
 
-                return doors;
+                return ReadOnlyDoorsValue;
             }
         }
 
         /// <summary>
         /// Gets all <see cref="Lift"/>.
         /// </summary>
-        public static List<Lift> Lifts
+        public static ReadOnlyCollection<Lift> Lifts
         {
             get
             {
-                if (lifts == null || lifts.Count == 0)
-                    lifts = Object.FindObjectsOfType<Lift>().ToList();
+                if (LiftsValue.Count == 0 || LiftsValue.Contains(null))
+                {
+                    LiftsValue.Clear();
+                    LiftsValue.AddRange(Object.FindObjectsOfType<Lift>());
+                }
 
-                return lifts;
+                return ReadOnlyLiftsValue;
             }
         }
 
         /// <summary>
         /// Gets all <see cref="TeslaGate"/>.
         /// </summary>
-        public static List<TeslaGate> TeslaGates
+        public static ReadOnlyCollection<TeslaGate> TeslaGates
         {
             get
             {
-                if (teslas == null || teslas.Count == 0)
-                    teslas = Object.FindObjectsOfType<TeslaGate>().ToList();
+                if (TeslasValue.Count == 0 || TeslasValue.Contains(null))
+                {
+                    TeslasValue.Clear();
+                    TeslasValue.AddRange(Object.FindObjectsOfType<TeslaGate>());
+                }
 
-                return teslas;
+                return ReadOnlyTeslasValue;
             }
         }
 

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -19,8 +19,6 @@ namespace Exiled.API.Features
     /// </summary>
     public class Room
     {
-        private ZoneType? zone;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Room"/> class.
         /// </summary>
@@ -32,12 +30,13 @@ namespace Exiled.API.Features
             Name = name;
             Transform = transform;
             Position = position;
+            Zone = FindZone();
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="Room"/> name.
+        /// Gets the <see cref="Room"/> name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets the <see cref="Room"/> <see cref="UnityEngine.Transform"/>.
@@ -45,52 +44,42 @@ namespace Exiled.API.Features
         public Transform Transform { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="Room"/> position.
+        /// Gets the <see cref="Room"/> position.
         /// </summary>
-        public Vector3 Position { get; set; }
+        public Vector3 Position { get; }
 
         /// <summary>
         /// Gets the <see cref="ZoneType"/> in which the room is located.
         /// </summary>
-        public ZoneType Zone
-        {
-            get
-            {
-                if (zone != null)
-                    return zone.Value;
-
-                if (Transform.parent == null)
-                {
-                    zone = ZoneType.Unspecified;
-                }
-                else
-                {
-                    switch (Transform.parent.name)
-                    {
-                        case "HeavyRooms":
-                            zone = ZoneType.HeavyContainment;
-                            break;
-                        case "LightRooms":
-                            zone = ZoneType.LightContainment;
-                            break;
-                        case "EntranceRooms":
-                            zone = ZoneType.Entrance;
-                            break;
-                        default:
-                            {
-                                zone = Position.y >= 5 ? ZoneType.Surface : ZoneType.Unspecified;
-                                break;
-                            }
-                    }
-                }
-
-                return zone.Value;
-            }
-        }
+        public ZoneType Zone { get; }
 
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Player"/> in the <see cref="Room"/>.
         /// </summary>
-        public IEnumerable<Player> Players => Player.List.Where(player => player.CurrentRoom.Name == Name);
+        public IEnumerable<Player> Players => Player.List.Where(player => player.CurrentRoom.Transform == Transform);
+
+        private ZoneType FindZone()
+        {
+            if (Transform.parent == null)
+            {
+                return ZoneType.Unspecified;
+            }
+            else
+            {
+                switch (Transform.parent.name)
+                {
+                    case "HeavyRooms":
+                        return ZoneType.HeavyContainment;
+                    case "LightRooms":
+                        return ZoneType.LightContainment;
+                    case "EntranceRooms":
+                        return ZoneType.Entrance;
+                    default:
+                        {
+                            return Position.y > 900 ? ZoneType.Surface : ZoneType.Unspecified;
+                        }
+                }
+            }
+        }
     }
 }

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -45,8 +45,8 @@ namespace Exiled.API.Features
         /// </summary>
         public static bool IsLobbyLocked
         {
-            get => GameCore.RoundStart.LobbyLock;
-            set => GameCore.RoundStart.LobbyLock = value;
+            get => RoundStart.LobbyLock;
+            set => RoundStart.LobbyLock = value;
         }
 
         /// <summary>

--- a/Exiled.Events/Events.cs
+++ b/Exiled.Events/Events.cs
@@ -72,6 +72,7 @@ namespace Exiled.Events
             Patch();
 
             Handlers.Server.WaitingForPlayers += round.OnWaitingForPlayers;
+            Handlers.Server.RestartingRound += round.OnRestartingRound;
             Handlers.Server.RoundStarted += round.OnRoundStarted;
 
             Handlers.Player.ChangingRole += round.OnChangingRole;
@@ -87,6 +88,7 @@ namespace Exiled.Events
             Unpatch();
 
             Handlers.Server.WaitingForPlayers -= round.OnWaitingForPlayers;
+            Handlers.Server.RestartingRound -= round.OnRestartingRound;
             Handlers.Server.RoundStarted -= round.OnRoundStarted;
 
             Handlers.Player.ChangingRole -= round.OnChangingRole;

--- a/Exiled.Events/Handlers/Round.cs
+++ b/Exiled.Events/Handlers/Round.cs
@@ -15,7 +15,7 @@ namespace Exiled.Events.Handlers
     /// <summary>
     /// Handles some round clean-up events and some others related to players.
     /// </summary>
-    public class Round
+    public sealed class Round
     {
         /// <inheritdoc cref="Server.OnWaitingForPlayers"/>
         public void OnWaitingForPlayers()
@@ -23,15 +23,15 @@ namespace Exiled.Events.Handlers
             if (Events.Instance.Config.ShouldReloadConfigsAtRoundRestart)
                 ConfigManager.Reload();
 
-            API.Features.Map.Rooms.Clear();
-            API.Features.Map.Doors.Clear();
-            API.Features.Map.Lifts.Clear();
-            API.Features.Map.TeslaGates.Clear();
+            RoundSummary.RoundLock = false;
+        }
 
+        /// <inheritdoc cref="Server.OnRestartingRound"/>
+        public void OnRestartingRound()
+        {
             API.Features.Player.IdsCache.Clear();
             API.Features.Player.UserIdsCache.Clear();
             API.Features.Player.Dictionary.Clear();
-            RoundSummary.RoundLock = false;
         }
 
         /// <inheritdoc cref="Server.OnRoundStarted"/>

--- a/Exiled.Events/Patches/Events/Server/RestartingRound.cs
+++ b/Exiled.Events/Patches/Events/Server/RestartingRound.cs
@@ -15,7 +15,7 @@ namespace Exiled.Events.Patches.Events.Server
     /// Adds the RestartingRound event.
     /// </summary>
     [HarmonyPatch(typeof(PlayerStats), nameof(PlayerStats.Roundrestart))]
-    internal class RestartingRound
+    internal static class RestartingRound
     {
         private static void Prefix()
         {


### PR DESCRIPTION
- Using ReadOnly collections instead of Lists to take away the ability to modify them.
- Take away the ability to assign a position and a name to the room.
- Updating API objects whenever the original unity object was destroyed (unity objects are managed from outside the managed CRL C# code, so they aren't collected by the GC and immediately destroyed).
- Change lazy initialization of a room zone to immediate.