### PR TITLE
Fixed escapingEventArgs.IsAllowed

### DIFF
--- a/Exiled.Events/Patches/Events/Player/ChangingRole.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingRole.cs
@@ -52,6 +52,9 @@ namespace Exiled.Events.Patches.Events.Player
 
                     Player.OnEscaping(escapingEventArgs);
 
+                    if (!escapingEventArgs.IsAllowed)
+                        return false;
+
                     classid = escapingEventArgs.NewRole;
                 }
 


### PR DESCRIPTION
Before that there was no check for IsAllowed.