### PR TITLE
DyingEventArgs ev.IsAllowed

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -55,7 +55,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                     Player.OnDying(dyingEventArgs);
 
-                    if (!ev.IsAllowed)
+                    if (!dyingEventArgs.IsAllowed)
                         return false;
                 }
 


### PR DESCRIPTION
Instead of dyingEventArgs.IsAllowed it was ev.IsAllowed and from that IsAllowd didn't work.