### PR TITLE
Revert "Fixed a bug that caused Map.Rooms Map.Doors Map.Lifts and Map…

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -27,6 +27,11 @@ namespace Exiled.API.Features
         private static readonly List<Lift> LiftsValue = new List<Lift>();
         private static readonly List<TeslaGate> TeslasValue = new List<TeslaGate>();
 
+        private static readonly ReadOnlyCollection<Room> ReadOnlyRoomsValue = RoomsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<Door> ReadOnlyDoorsValue = DoorsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<Lift> ReadOnlyLiftsValue = LiftsValue.AsReadOnly();
+        private static readonly ReadOnlyCollection<TeslaGate> ReadOnlyTeslasValue = TeslasValue.AsReadOnly();
+
         /// <summary>
         /// Gets a value indicating whether the decontamination has been completed or not.
         /// </summary>
@@ -55,7 +60,7 @@ namespace Exiled.API.Features
                     RoomsValue.AddRange(GameObject.FindGameObjectsWithTag("Room").Select(r => new Room(r.name, r.transform, r.transform.position)));
                 }
 
-                return RoomsValue.AsReadOnly();
+                return ReadOnlyRoomsValue;
             }
         }
 
@@ -72,7 +77,7 @@ namespace Exiled.API.Features
                     DoorsValue.AddRange(Object.FindObjectsOfType<Door>());
                 }
 
-                return DoorsValue.AsReadOnly();
+                return ReadOnlyDoorsValue;
             }
         }
 
@@ -89,7 +94,7 @@ namespace Exiled.API.Features
                     LiftsValue.AddRange(Object.FindObjectsOfType<Lift>());
                 }
 
-                return LiftsValue.AsReadOnly();
+                return ReadOnlyLiftsValue;
             }
         }
 
@@ -106,7 +111,7 @@ namespace Exiled.API.Features
                     TeslasValue.AddRange(Object.FindObjectsOfType<TeslaGate>());
                 }
 
-                return TeslasValue.AsReadOnly();
+                return ReadOnlyTeslasValue;
             }
         }
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -153,6 +153,5 @@ namespace Exiled.API.Features
             LiftsValue.Clear();
             TeslasValue.Clear();
         }
-
     }
 }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -104,17 +104,6 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        ///     Clears the lazy loading game object cache.
-        /// </summary>
-        internal static void CleanCache()
-        {
-            RoomsValue.Clear();
-            DoorsValue.Clear();
-            LiftsValue.Clear();
-            TeslasValue.Clear();
-        }
-
-        /// <summary>
         /// Broadcasts a message to all players.
         /// </summary>
         /// <param name="duration">The duration in seconds.</param>
@@ -153,5 +142,17 @@ namespace Exiled.API.Features
         /// <param name="duration">The duration of the blackout.</param>
         /// <param name="isHeavyContainmentZoneOnly">Indicates whether only the heavy containment zone lights have to be turned off or not.</param>
         public static void TurnOffAllLights(float duration, bool isHeavyContainmentZoneOnly = false) => Generator079.Generators[0].RpcCustomOverchargeForOurBeautifulModCreators(duration, isHeavyContainmentZoneOnly);
+
+        /// <summary>
+        ///     Clears the lazy loading game object cache.
+        /// </summary>
+        internal static void ClearCache()
+        {
+            RoomsValue.Clear();
+            DoorsValue.Clear();
+            LiftsValue.Clear();
+            TeslasValue.Clear();
+        }
+
     }
 }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -54,11 +54,8 @@ namespace Exiled.API.Features
         {
             get
             {
-                if (RoomsValue.Count == 0 || RoomsValue.Any(r => r.Transform == null))
-                {
-                    RoomsValue.Clear();
+                if (RoomsValue.Count == 0)
                     RoomsValue.AddRange(GameObject.FindGameObjectsWithTag("Room").Select(r => new Room(r.name, r.transform, r.transform.position)));
-                }
 
                 return ReadOnlyRoomsValue;
             }
@@ -71,11 +68,8 @@ namespace Exiled.API.Features
         {
             get
             {
-                if (DoorsValue.Count == 0 || DoorsValue.Contains(null))
-                {
-                    DoorsValue.Clear();
+                if (DoorsValue.Count == 0)
                     DoorsValue.AddRange(Object.FindObjectsOfType<Door>());
-                }
 
                 return ReadOnlyDoorsValue;
             }
@@ -88,11 +82,8 @@ namespace Exiled.API.Features
         {
             get
             {
-                if (LiftsValue.Count == 0 || LiftsValue.Contains(null))
-                {
-                    LiftsValue.Clear();
+                if (LiftsValue.Count == 0)
                     LiftsValue.AddRange(Object.FindObjectsOfType<Lift>());
-                }
 
                 return ReadOnlyLiftsValue;
             }
@@ -105,14 +96,22 @@ namespace Exiled.API.Features
         {
             get
             {
-                if (TeslasValue.Count == 0 || TeslasValue.Contains(null))
-                {
-                    TeslasValue.Clear();
+                if (TeslasValue.Count == 0)
                     TeslasValue.AddRange(Object.FindObjectsOfType<TeslaGate>());
-                }
 
                 return ReadOnlyTeslasValue;
             }
+        }
+
+        /// <summary>
+        ///     Clears the lazy loading game object cache.
+        /// </summary>
+        internal static void CleanCache()
+        {
+            RoomsValue.Clear();
+            DoorsValue.Clear();
+            LiftsValue.Clear();
+            TeslasValue.Clear();
         }
 
         /// <summary>

--- a/Exiled.API/Properties/AssemblyInfo.cs
+++ b/Exiled.API/Properties/AssemblyInfo.cs
@@ -6,6 +6,7 @@
 // -----------------------------------------------------------------------
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // Le informazioni generali relative a un assembly sono controllate dal seguente
@@ -40,3 +41,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.5")]
 [assembly: AssemblyFileVersion("2.0.5")]
+[assembly: InternalsVisibleTo("Exiled.Events")]

--- a/Exiled.Events/Handlers/Round.cs
+++ b/Exiled.Events/Handlers/Round.cs
@@ -32,7 +32,7 @@ namespace Exiled.Events.Handlers
             API.Features.Player.IdsCache.Clear();
             API.Features.Player.UserIdsCache.Clear();
             API.Features.Player.Dictionary.Clear();
-            API.Features.Map.CleanCache();
+            API.Features.Map.ClearCache();
         }
 
         /// <inheritdoc cref="Server.OnRoundStarted"/>

--- a/Exiled.Events/Handlers/Round.cs
+++ b/Exiled.Events/Handlers/Round.cs
@@ -32,6 +32,7 @@ namespace Exiled.Events.Handlers
             API.Features.Player.IdsCache.Clear();
             API.Features.Player.UserIdsCache.Clear();
             API.Features.Player.Dictionary.Clear();
+            API.Features.Map.CleanCache();
         }
 
         /// <inheritdoc cref="Server.OnRoundStarted"/>


### PR DESCRIPTION
….TeslaGates to always return a null readonlycollection."

This reverts commit 8d448c13a3537c6584e9e45dba95e6824c89880e.

`ReadOnlyCollection`'s is a wrapper around accessing the main collections without copying all values.