### PR TITLE
Fix ignore IsAllowed EscapingPocketDimensionEventArgs

### DIFF
--- a/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
@@ -116,6 +116,7 @@ namespace Exiled.Events.Patches.Events.Player
                             .TargetAchieve(component1.connectionToClient, "larryisyourfriend");
                     }
                 }
+
                 if (!__instance.RefreshExit)
                     return false;
                 ImageGenerator.pocketDimensionGenerator.GenerateRandom();

--- a/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
@@ -116,10 +116,6 @@ namespace Exiled.Events.Patches.Events.Player
                             .TargetAchieve(component1.connectionToClient, "larryisyourfriend");
                     }
 
-                    component2.OverridePosition(tpPosition, 0.0f, false);
-                    __instance.RemoveCorrosionEffect(other.gameObject);
-                    PlayerManager.localPlayer.GetComponent<PlayerStats>()
-                        .TargetAchieve(component1.connectionToClient, "larryisyourfriend");
                 }
 
                 if (!__instance.RefreshExit)

--- a/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
@@ -115,7 +115,6 @@ namespace Exiled.Events.Patches.Events.Player
                         PlayerManager.localPlayer.GetComponent<PlayerStats>()
                             .TargetAchieve(component1.connectionToClient, "larryisyourfriend");
                     }
-
                 }
 
                 if (!__instance.RefreshExit)

--- a/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
+++ b/Exiled.Events/Patches/Events/Player/EscapingAndFailingEscapePocketDimension.cs
@@ -116,7 +116,6 @@ namespace Exiled.Events.Patches.Events.Player
                             .TargetAchieve(component1.connectionToClient, "larryisyourfriend");
                     }
                 }
-
                 if (!__instance.RefreshExit)
                     return false;
                 ImageGenerator.pocketDimensionGenerator.GenerateRandom();


### PR DESCRIPTION
Even if IsAllowed = false was set, the player exited the pocket anyway