### PR TITLE
Fix the LocalReporting event & convert to IL

### DIFF
--- a/Exiled.Events/Handlers/Server.cs
+++ b/Exiled.Events/Handlers/Server.cs
@@ -149,7 +149,20 @@ namespace Exiled.Events.Handlers
         /// Called when sending a complaint about a player to the local server administrators.
         /// </summary>
         /// <param name="ev">The <see cref="LocalReportingEventArgs"/> instance.</param>
-        public static void OnLocalReporting(LocalReportingEventArgs ev) => LocalReporting.InvokeSafely(ev);
+        public static void OnLocalReporting(LocalReportingEventArgs ev)
+        {
+#if DEBUG
+            void LogL(string s) =>
+                Log.Debug($"{nameof(Server)}-{nameof(OnLocalReporting)}: {s}", true);
+
+            LogL($"Original reason: {ev.Reason}");
+            ev.Reason = "some random reason for debug";
+            LogL($"Replaced reason: {ev.Reason}");
+            LogL($"{nameof(ev.Target)} is null: {ev.Target == null}");
+            LogL($"{nameof(ev.Issuer)} is null: {ev.Issuer == null}");
+#endif
+            LocalReporting.InvokeSafely(ev);
+        }
 
         /// <summary>
         /// Called after the "reload configs" command is ran.

--- a/Exiled.Events/Patches/Events/Server/LocalReporting.cs
+++ b/Exiled.Events/Patches/Events/Server/LocalReporting.cs
@@ -14,6 +14,7 @@ namespace Exiled.Events.Patches.Events.Server
     using HarmonyLib;
 
 #pragma warning disable RCS1139 // Add summary element to documentation comment.
+#pragma warning disable CS1570 // XML comment has badly formed XML
     /// <remarks>
     /// <para>
     ///     Code before patching:
@@ -90,6 +91,7 @@ namespace Exiled.Events.Patches.Events.Server
     /// </summary>
     [HarmonyPatch(typeof(CheaterReport), nameof(CheaterReport.CallCmdReport), typeof(int), typeof(string), typeof(byte[]), typeof(bool))]
 #pragma warning restore RCS1139 // Add summary element to documentation comment.
+#pragma warning restore CS1570 // XML comment has badly formed XML
 #pragma warning disable SA1604 // Element documentation should have summary
     internal static class LocalReporting
 #pragma warning restore SA1604 // Element documentation should have summary

--- a/Exiled.Events/Patches/Events/Server/LocalReporting.cs
+++ b/Exiled.Events/Patches/Events/Server/LocalReporting.cs
@@ -46,10 +46,10 @@ namespace Exiled.Events.Patches.Events.Server
     ///         ldloc.s 5
     ///         ldloc.0
     ///         ldflda System.String<>c__DisplayClass14_0::reason
-    ///         call static System.Void Exiled.Events.Patches.Events.Server.LocalReporting::SuperReasonReplacer(Exiled.Events.EventArgs.LocalReportingEventArgs ev, System.String& reason)
+    ///         call static System.Void Exiled.Events.Patches.Events.Server.LocalReporting::SuperReasonReplacer(Exiled.Events.EventArgs.LocalReportingEventArgs ev, ref System.String reason)
     ///         ldloc.s 5
     ///         ldarga.s 2
-    ///         call static System.Void Exiled.Events.Patches.Events.Server.LocalReporting::SuperReasonReplacer(Exiled.Events.EventArgs.LocalReportingEventArgs ev, System.String& reason)
+    ///         call static System.Void Exiled.Events.Patches.Events.Server.LocalReporting::SuperReasonReplacer(Exiled.Events.EventArgs.LocalReportingEventArgs ev, ref System.String reason)
     ///         ldloc.s 5
     ///         call System.String Exiled.Events.EventArgs.LocalReportingEventArgs::get_Reason()
     ///         ldc.i4.1


### PR DESCRIPTION
## Fixes
- `Target`  is no longer null in the `LocalReportingEventArgs`.
- `Reason` changes the final reason.
- Rejecting a report no longer triggers a successful message for clients.

## Misc
- `LocalReporting` converted to IL patch.