### PR TITLE
Fixed OnDying event

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -49,7 +49,7 @@ namespace Exiled.Events.Patches.Events.Player
                 if (!ev.IsAllowed)
                     return false;
 
-                if (ev.Amount >= ev.Target.Health + ev.Target.AdrenalineHealth)
+                if (ev.Amount == -1 || ev.Amount >= ev.Target.Health + ev.Target.AdrenalineHealth)
                 {
                     var dyingEventArgs = new DyingEventArgs(ev.Attacker, ev.Target, ev.HitInformations);
 


### PR DESCRIPTION
OnDying is now triggered when ev.Amount is -1 (used with nuke damage, player.Kill/Hurt)