### PR TITLE
Optimize the player global badge API

### DIFF
--- a/Exiled.API/Features/Badge.cs
+++ b/Exiled.API/Features/Badge.cs
@@ -30,21 +30,21 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the badge text.
         /// </summary>
-        public string Text { get; }
+        public string Text { get; private set; }
 
         /// <summary>
         /// Gets the badge color.
         /// </summary>
-        public string Color { get; }
+        public string Color { get; private set; }
 
         /// <summary>
         /// Gets the badge type.
         /// </summary>
-        public int Type { get; }
+        public int Type { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether the badge is global or not.
         /// </summary>
-        public bool IsGlobal { get; }
+        public bool IsGlobal { get; private set; }
     }
 }

--- a/Exiled.API/Features/Badge.cs
+++ b/Exiled.API/Features/Badge.cs
@@ -10,10 +10,10 @@ namespace Exiled.API.Features
     /// <summary>
     /// Represents the in-game badge.
     /// </summary>
-    public class Badge
+    public struct Badge
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Badge"/> class.
+        /// Initializes a new instance of the <see cref="Badge"/> struct.
         /// </summary>
         /// <param name="text">The badge text.</param>
         /// <param name="color">The badge color.</param>
@@ -30,21 +30,21 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the badge text.
         /// </summary>
-        public string Text { get; private set; }
+        public string Text { get; }
 
         /// <summary>
         /// Gets the badge color.
         /// </summary>
-        public string Color { get; private set; }
+        public string Color { get; }
 
         /// <summary>
         /// Gets the badge type.
         /// </summary>
-        public int Type { get; private set; }
+        public int Type { get; }
 
         /// <summary>
         /// Gets a value indicating whether the badge is global or not.
         /// </summary>
-        public bool IsGlobal { get; private set; }
+        public bool IsGlobal { get; }
     }
 }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -631,21 +631,17 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the global badge of the player, can be null if none.
         /// </summary>
-        public Badge GlobalBadge
+        public Badge? GlobalBadge
         {
             get
             {
-                string token = ReferenceHub.serverRoles.NetworkGlobalBadge;
+                var token = ReferenceHub.serverRoles.NetworkGlobalBadge;
 
                 if (string.IsNullOrEmpty(token))
                     return null;
 
-                Dictionary<string, string> dictionary = (from target in token.Split(new string[] { "<br>" }, StringSplitOptions.None)
-                                                         select target.Split(
-                                                             new string[] { ": " },
-                                                             StringSplitOptions.None)).ToDictionary(split => split[0], split => split[1]);
-
-                return int.TryParse(dictionary["Badge type"], out int badgeType) ? null : new Badge(dictionary["Badge text"], dictionary["Badge color"], badgeType, true);
+                var serverRoles = ReferenceHub.serverRoles;
+                return new Badge(serverRoles._bgt, serverRoles._bgc, serverRoles.GlobalBadgeType, true);
             }
         }
 
@@ -755,7 +751,7 @@ namespace Exiled.API.Features
 
                     foreach (Player player in Dictionary.Values)
                     {
-                        if (!player.Nickname.ToLower().Contains(args.ToLower()))
+                        if (!player.Nickname.Contains(args, StringComparison.OrdinalIgnoreCase))
                             continue;
 
                         if (firstString.Length < maxNameLength)


### PR DESCRIPTION
- Using the structure prevents the `Badge` from getting into the managed heap.
- Optimization of getting `Badge` without creating a dictionary and manual parsing.