### PR TITLE
Fix RA vulnerability

### DIFF
--- a/Exiled.Events/Patches/Events/Server/SendingRemoteAdminCommand.cs
+++ b/Exiled.Events/Patches/Events/Server/SendingRemoteAdminCommand.cs
@@ -51,7 +51,7 @@ namespace Exiled.Events.Patches.Events.Server
                 }
             }
 
-            if (q.Contains("REQUEST_DATA PLAYER_LIST SILENT"))
+            if (q == "REQUEST_DATA PLAYER_LIST SILENT")
                 return true;
 
             Handlers.Server.OnSendingRemoteAdminCommand(ev);


### PR DESCRIPTION
Commands can bypass plugins' ra command handlers, if contains REQUEST_DATA PLAYER_LIST SILENT