### PR TITLE
Include assembly name in Exiled.Loader error

### DIFF
--- a/Exiled.Loader/Loader.cs
+++ b/Exiled.Loader/Loader.cs
@@ -200,7 +200,7 @@ namespace Exiled.Loader
             }
             catch (Exception exception)
             {
-                Log.Error($"Error while initializing plugin at {assembly.Location}! {exception}");
+                Log.Error($"Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
             }
 
             return null;


### PR DESCRIPTION
This makes the error message a bit more descriptive.