### PR TITLE
Implement IEquatable on Player.

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -24,7 +24,7 @@ namespace Exiled.API.Features
     /// <summary>
     /// Represents the in-game player, by encapsulating a <see cref="ReferenceHub"/>.
     /// </summary>
-    public class Player
+    public class Player : IEquatable<Player>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Player"/> class.
@@ -1062,5 +1062,17 @@ namespace Exiled.API.Features
 
         /// <inheritdoc/>
         public override string ToString() => $"{Id} {Nickname} {UserId}";
+
+        /// <inheritdoc/>
+        public bool Equals(Player other)
+        {
+            return this.UserId == other.UserId && this.IPAddress == other.IPAddress && this.Id == other.Id;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is Player ply && ply.Equals(this);
+        }
     }
 }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1076,5 +1076,15 @@ namespace Exiled.API.Features
         {
             return obj is Player ply && ply.Equals(this);
         }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hash = base.GetHashCode();
+            hash ^= UserId.GetHashCode();
+            hash ^= IPAddress.GetHashCode();
+            hash ^= Id.GetHashCode();
+            return hash;
+        }
     }
 }

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1066,7 +1066,9 @@ namespace Exiled.API.Features
         /// <inheritdoc/>
         public bool Equals(Player other)
         {
-            return this.UserId == other.UserId && this.IPAddress == other.IPAddress && this.Id == other.Id;
+            if (other == null)
+                return false;
+            return UserId == other.UserId && IPAddress == other.IPAddress && Id == other.Id;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Allows developers to use the equality operator when checking if two Player objects represent the same person.
- Implements `IEquatable<Player>` on Player