### PR TITLE
Fix link to NWlib & remove NuGet.config

### DIFF
--- a/Exiled.API/Exiled.API.csproj
+++ b/Exiled.API/Exiled.API.csproj
@@ -52,7 +52,7 @@
     </Reference>
     <Reference Include="NorthwoodLib, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\References\NorthwoodLib.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\NorthwoodLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">

--- a/Exiled.Events/Exiled.Events.csproj
+++ b/Exiled.Events/Exiled.Events.csproj
@@ -56,7 +56,7 @@
       <HintPath>$(EXILED_REFERENCES)\Mirror.dll</HintPath>
     </Reference>
     <Reference Include="NorthwoodLib">
-      <HintPath>..\..\References\NorthwoodLib.dll</HintPath>
+      <HintPath>$(EXILED_REFERENCES)\NorthwoodLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <config>
-    <add key="globalPackagesFolder" value=".\packages" />
-  </config>
-</configuration>


### PR DESCRIPTION
NuGet.config overrides `globalPackagesFolder`, some peoples have this override in their global NuGet.config (like me). Some projects use the same dependencies, and it becomes terrible to watch all traffic with `dotnet restore` /`nuget restore`, **__Also nuget by default uses the `packages` folder as the packages folder if there is no global folder.__**