### PR TITLE
Add the Player::DisplayNickname API

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -141,7 +141,7 @@ namespace Exiled.API.Features
             get => ReferenceHub.characterClassManager.UserId;
             set
             {
-                ReferenceHub.characterClassManager.UserId = value ?? throw new ArgumentNullException($"UserId cannot be set to null.");
+                ReferenceHub.characterClassManager.UserId = value ?? throw new ArgumentNullException("UserId cannot be set to null.");
             }
         }
 
@@ -194,13 +194,19 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Gets or sets the player's nickname.
+        /// Gets or sets the player's display nickname.
+        /// May be null.
         /// </summary>
-        public string Nickname
+        public string DisplayNickname
         {
-            get => ReferenceHub.nicknameSync.Network_displayName ?? ReferenceHub.nicknameSync.Network_myNickSync;
+            get => ReferenceHub.nicknameSync.Network_displayName;
             set => ReferenceHub.nicknameSync.Network_displayName = value;
         }
+
+        /// <summary>
+        /// Gets the player's nickname.
+        /// </summary>
+        public string Nickname => ReferenceHub.nicknameSync.Network_myNickSync;
 
         /// <summary>
         /// Gets or sets a value indicating whether the player is invisible or not.


### PR DESCRIPTION
These changes are due to the fact that plugins, after assigning a display nickname, cannot get the player's original nickname, although in some cases this is necessary.