### PR TITLE
DoorTypes -- 

### DIFF
--- a/Exiled.API/Enums/DoorType.cs
+++ b/Exiled.API/Enums/DoorType.cs
@@ -14,197 +14,197 @@ namespace Exiled.API.Enums
     {
         /// <summary>
         /// Represents the 012 door.
-        /// <summary>
+        /// </summary>
         Scp012,
 
         /// <summary>
         /// Represents the 012_BOTTOM door.
-        /// <summary>
+        /// </summary>
         Scp012Bottom,
 
         /// <summary>
         /// Represents the 012_LOCKER door.
-        /// <summary>
+        /// </summary>
         Scp012Locker,
 
         /// <summary>
         /// Represents the 049_ARMORY door.
-        /// <summary>
+        /// </summary>
         Scp049Armory,
 
         /// <summary>
         /// Represents the 079_FIRST door.
-        /// <summary>
+        /// </summary>
         Scp079First,
 
         /// <summary>
         /// Represents the 079_SECOND door.
-        /// <summary>
+        /// </summary>
         Scp079Second,
 
         /// <summary>
         /// Represents the 096 door.
-        /// <summary>
+        /// </summary>
         Scp096,
 
         /// <summary>
         /// Represents the 106_BOTTOM door.
-        /// <summary>
+        /// </summary>
         Scp106Bottom,
 
         /// <summary>
         /// Represents the 106_PRIMARY door.
-        /// <summary>
+        /// </summary>
         Scp106Primary,
 
         /// <summary>
         /// Represents the 106_SECONDARY door.
-        /// <summary>
+        /// </summary>
         Scp106Secondary,
 
         /// <summary>
         /// Represents the 173 door.
-        /// <summary>
+        /// </summary>
         Scp173,
 
         /// <summary>
         /// Represents the 173_ARMORY door.
-        /// <summary>
+        /// </summary>
         Scp173Armory,
 
         /// <summary>
         /// Represents the 173_BOTTOM door.
-        /// <summary>
+        /// </summary>
         Scp173Bottom,
 
         /// <summary>
         /// Represents the 372 door.
-        /// <summary>
+        /// </summary>
         Scp372,
 
         /// <summary>
         /// Represents the 914 door.
-        /// <summary>
+        /// </summary>
         Scp914,
 
         /// <summary>
         /// Represents the Airlocks door.
-        /// <summary>
+        /// </summary>
         Airlocks,
 
         /// <summary>
         /// Represents the CHECKPOINT_ENT door.
-        /// <summary>
+        /// </summary>
         CheckpointEntrance,
 
         /// <summary>
         /// Represents the CHECKPOINT_LCZ_A door.
-        /// <summary>
+        /// </summary>
         CheckpointLczA,
 
         /// <summary>
         /// Represents the CHECKPOINT_LCZ_B door.
-        /// <summary>
+        /// </summary>
         CheckpointLczB,
 
         /// <summary>
         /// Represents the ContDoor door.
-        /// <summary>
+        /// </summary>
         ContDoor,
 
         /// <summary>
         /// Represents the EntrDoor door.
-        /// <summary>
+        /// </summary>
         EntranceDoor,
 
         /// <summary>
         /// Represents the ESCAPE door.
-        /// <summary>
+        /// </summary>
         Escape,
 
         /// <summary>
         /// Represents the ESCAPE_INNER door.
-        /// <summary>
+        /// </summary>
         EscapeInner,
 
         /// <summary>
         /// Represents the GATE_A door.
-        /// <summary>
+        /// </summary>
         GateA,
 
         /// <summary>
         /// Represents the GATE_B door.
-        /// <summary>
+        /// </summary>
         GateB,
 
         /// <summary>
         /// Represents the HCZ_ARMORY door.
-        /// <summary>
+        /// </summary>
         HczArmory,
 
         /// <summary>
         /// Represents the HeavyContainmentDoor door.
-        /// <summary>
+        /// </summary>
         HeavyContainmentDoor,
 
         /// <summary>
         /// Represents the HID door.
-        /// <summary>
+        /// </summary>
         HID,
 
         /// <summary>
         /// Represents the HID_LEFT door.
-        /// <summary>
+        /// </summary>
         HIDLeft,
 
         /// <summary>
         /// Represents the HID_RIGHT door.
-        /// <summary>
+        /// </summary>
         HIDRight,
 
         /// <summary>
         /// Represents the INTERCOM door.
-        /// <summary>
+        /// </summary>
         Intercom,
 
         /// <summary>
         /// Represents the LCZ_ARMORY door.
-        /// <summary>
+        /// </summary>
         LczArmory,
 
         /// <summary>
         /// Represents the LCZ_CAFE door.
-        /// <summary>
+        /// </summary>
         LczCafe,
 
         /// <summary>
         /// Represents the LCZ_WC door.
-        /// <summary>
+        /// </summary>
         LczWc,
 
         /// <summary>
         /// Represents the LightContainmentDoor door.
-        /// <summary>
+        /// </summary>
         LightContainmentDoor,
 
         /// <summary>
         /// Represents the NUKE_ARMORY door.
-        /// <summary>
+        /// </summary>
         NukeArmory,
 
         /// <summary>
         /// Represents the NUKE_SURFACE door.
-        /// <summary>
+        /// </summary>
         NukeSurface,
 
         /// <summary>
         /// Represents the PrisonDoor door.
-        /// <summary>
+        /// </summary>
         PrisonDoor,
 
         /// <summary>
         /// Represents the SURFACE_GATE door.
-        /// <summary>
+        /// </summary>
         SurfaceGate,
 
         /// <summary>

--- a/Exiled.API/Enums/DoorType.cs
+++ b/Exiled.API/Enums/DoorType.cs
@@ -1,0 +1,215 @@
+// -----------------------------------------------------------------------
+// <copyright file="DoorType.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Enums
+{
+    /// <summary>
+    /// Unique identifier for the different types of doors.
+    /// </summary>
+    public enum DoorType
+    {
+        /// <summary>
+        /// Represents the 012 door.
+        /// <summary>
+        Scp012,
+
+        /// <summary>
+        /// Represents the 012_BOTTOM door.
+        /// <summary>
+        Scp012Bottom,
+
+        /// <summary>
+        /// Represents the 012_LOCKER door.
+        /// <summary>
+        Scp012Locker,
+
+        /// <summary>
+        /// Represents the 049_ARMORY door.
+        /// <summary>
+        Scp049Armory,
+
+        /// <summary>
+        /// Represents the 079_FIRST door.
+        /// <summary>
+        Scp079First,
+
+        /// <summary>
+        /// Represents the 079_SECOND door.
+        /// <summary>
+        Scp079Second,
+
+        /// <summary>
+        /// Represents the 096 door.
+        /// <summary>
+        Scp096,
+
+        /// <summary>
+        /// Represents the 106_BOTTOM door.
+        /// <summary>
+        Scp106Bottom,
+
+        /// <summary>
+        /// Represents the 106_PRIMARY door.
+        /// <summary>
+        Scp106Primary,
+
+        /// <summary>
+        /// Represents the 106_SECONDARY door.
+        /// <summary>
+        Scp106Secondary,
+
+        /// <summary>
+        /// Represents the 173 door.
+        /// <summary>
+        Scp173,
+
+        /// <summary>
+        /// Represents the 173_ARMORY door.
+        /// <summary>
+        Scp173Armory,
+
+        /// <summary>
+        /// Represents the 173_BOTTOM door.
+        /// <summary>
+        Scp173Bottom,
+
+        /// <summary>
+        /// Represents the 372 door.
+        /// <summary>
+        Scp372,
+
+        /// <summary>
+        /// Represents the 914 door.
+        /// <summary>
+        Scp914,
+
+        /// <summary>
+        /// Represents the Airlocks door.
+        /// <summary>
+        Airlocks,
+
+        /// <summary>
+        /// Represents the CHECKPOINT_ENT door.
+        /// <summary>
+        CheckpointEntrance,
+
+        /// <summary>
+        /// Represents the CHECKPOINT_LCZ_A door.
+        /// <summary>
+        CheckpointLczA,
+
+        /// <summary>
+        /// Represents the CHECKPOINT_LCZ_B door.
+        /// <summary>
+        CheckpointLczB,
+
+        /// <summary>
+        /// Represents the ContDoor door.
+        /// <summary>
+        ContDoor,
+
+        /// <summary>
+        /// Represents the EntrDoor door.
+        /// <summary>
+        EntranceDoor,
+
+        /// <summary>
+        /// Represents the ESCAPE door.
+        /// <summary>
+        Escape,
+
+        /// <summary>
+        /// Represents the ESCAPE_INNER door.
+        /// <summary>
+        EscapeInner,
+
+        /// <summary>
+        /// Represents the GATE_A door.
+        /// <summary>
+        GateA,
+
+        /// <summary>
+        /// Represents the GATE_B door.
+        /// <summary>
+        GateB,
+
+        /// <summary>
+        /// Represents the HCZ_ARMORY door.
+        /// <summary>
+        HczArmory,
+
+        /// <summary>
+        /// Represents the HeavyContainmentDoor door.
+        /// <summary>
+        HeavyContainmentDoor,
+
+        /// <summary>
+        /// Represents the HID door.
+        /// <summary>
+        HID,
+
+        /// <summary>
+        /// Represents the HID_LEFT door.
+        /// <summary>
+        HIDLeft,
+
+        /// <summary>
+        /// Represents the HID_RIGHT door.
+        /// <summary>
+        HIDRight,
+
+        /// <summary>
+        /// Represents the INTERCOM door.
+        /// <summary>
+        Intercom,
+
+        /// <summary>
+        /// Represents the LCZ_ARMORY door.
+        /// <summary>
+        LczArmory,
+
+        /// <summary>
+        /// Represents the LCZ_CAFE door.
+        /// <summary>
+        LczCafe,
+
+        /// <summary>
+        /// Represents the LCZ_WC door.
+        /// <summary>
+        LczWc,
+
+        /// <summary>
+        /// Represents the LightContainmentDoor door.
+        /// <summary>
+        LightContainmentDoor,
+
+        /// <summary>
+        /// Represents the NUKE_ARMORY door.
+        /// <summary>
+        NukeArmory,
+
+        /// <summary>
+        /// Represents the NUKE_SURFACE door.
+        /// <summary>
+        NukeSurface,
+
+        /// <summary>
+        /// Represents the PrisonDoor door.
+        /// <summary>
+        PrisonDoor,
+
+        /// <summary>
+        /// Represents the SURFACE_GATE door.
+        /// <summary>
+        SurfaceGate,
+
+        /// <summary>
+        /// Represents an unknown door.
+        /// </summary>
+        UnknownDoor,
+    }
+}

--- a/Exiled.API/Extensions/DoorTypeExtension.cs
+++ b/Exiled.API/Extensions/DoorTypeExtension.cs
@@ -1,0 +1,143 @@
+// -----------------------------------------------------------------------
+// <copyright file="DoorTypeExtension.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Extensions
+{
+    using System.Collections.Generic;
+
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains an extension method to get <see cref="DoorType"/> from <see cref="Door"/>.
+    /// Internal class <see cref="RegisterDoorTypesOnLevelLoad"/> to cache the <see cref="DoorType"/> on level load.
+    /// </summary>
+    public static class DoorTypeExtension
+    {
+        private static readonly Dictionary<int, DoorType> OrderedDoorTypes = new Dictionary<int, DoorType>();
+
+        /// <summary>
+        /// Gets the <see cref="DoorType"/>.
+        /// </summary>
+        /// <param name="door">The Door to check.</param>
+        /// <returns>The <see cref="DoorType"/>.</returns>
+        public static DoorType Type(this Door door) => OrderedDoorTypes.TryGetValue(door.GetInstanceID(), out var doorType) ? doorType : DoorType.UnknownDoor;
+
+        /// <summary>
+        /// Gets all the <see cref="DoorType"/> values for for the <see cref="Door"/> instances using <see cref="Door.DoorName"/> and <see cref="UnityEngine.GameObject"/> name.
+        /// </summary>
+        internal static void RegisterDoorTypesOnLevelLoad()
+        {
+            OrderedDoorTypes.Clear();
+
+            var doors = Map.Doors;
+
+            if (doors == null)
+                return;
+
+            var doorCount = doors.Count;
+            for (int i = 0; i < doorCount; i++)
+            {
+                var door = doors[i];
+                var doorID = door.GetInstanceID();
+
+                var doorName = string.IsNullOrWhiteSpace(door.DoorName) ? door.name.RemoveBracketsOnEndOfName() : door.DoorName;
+
+                var doorType = GetDoorType(doorName);
+
+                OrderedDoorTypes.Add(doorID, doorType);
+            }
+        }
+
+        private static DoorType GetDoorType(string doorName)
+        {
+            switch (doorName)
+            {
+                case "012":
+                return DoorType.Scp012;
+                case "012_BOTTOM":
+                return DoorType.Scp012Bottom;
+                case "012_LOCKER":
+                return DoorType.Scp012Locker;
+                case "049_ARMORY":
+                return DoorType.Scp049Armory;
+                case "079_FIRST":
+                return DoorType.Scp079First;
+                case "079_SECOND":
+                return DoorType.Scp079Second;
+                case "096":
+                return DoorType.Scp096;
+                case "106_BOTTOM":
+                return DoorType.Scp106Bottom;
+                case "106_PRIMARY":
+                return DoorType.Scp106Primary;
+                case "106_SECONDARY":
+                return DoorType.Scp106Secondary;
+                case "173":
+                return DoorType.Scp173;
+                case "173_ARMORY":
+                return DoorType.Scp173Armory;
+                case "173_BOTTOM":
+                return DoorType.Scp173Bottom;
+                case "372":
+                return DoorType.Scp372;
+                case "914":
+                return DoorType.Scp914;
+                case "Airlocks":
+                return DoorType.Airlocks;
+                case "CHECKPOINT_ENT":
+                return DoorType.CheckpointEntrance;
+                case "CHECKPOINT_LCZ_A":
+                return DoorType.CheckpointLczA;
+                case "CHECKPOINT_LCZ_B":
+                return DoorType.CheckpointLczB;
+                case "ContDoor":
+                return DoorType.ContDoor;
+                case "EntrDoor":
+                return DoorType.EntranceDoor;
+                case "ESCAPE":
+                return DoorType.Escape;
+                case "ESCAPE_INNER":
+                return DoorType.EscapeInner;
+                case "GATE_A":
+                return DoorType.GateA;
+                case "GATE_B":
+                return DoorType.GateB;
+                case "HCZ_ARMORY":
+                return DoorType.HczArmory;
+                case "HeavyContainmentDoor":
+                return DoorType.HeavyContainmentDoor;
+                case "HID":
+                return DoorType.HID;
+                case "HID_LEFT":
+                return DoorType.HIDLeft;
+                case "HID_RIGHT":
+                return DoorType.HIDRight;
+                case "INTERCOM":
+                return DoorType.Intercom;
+                case "LCZ_ARMORY":
+                return DoorType.LczArmory;
+                case "LCZ_CAFE":
+                return DoorType.LczCafe;
+                case "LCZ_WC":
+                return DoorType.LczWc;
+                case "LightContainmentDoor":
+                return DoorType.LightContainmentDoor;
+                case "NUKE_ARMORY":
+                return DoorType.NukeArmory;
+                case "NUKE_SURFACE":
+                return DoorType.NukeSurface;
+                case "PrisonDoor":
+                return DoorType.PrisonDoor;
+                case "SURFACE_GATE":
+                return DoorType.SurfaceGate;
+                default:
+                return DoorType.UnknownDoor;
+            }
+        }
+    }
+}

--- a/Exiled.API/Extensions/String.cs
+++ b/Exiled.API/Extensions/String.cs
@@ -115,5 +115,20 @@ namespace Exiled.API.Extensions
 
             return result;
         }
+
+        /// <summary>
+        /// Removes the prefab-generated brackets (#) on <see cref="UnityEngine.GameObject"/> names.
+        /// </summary>
+        /// <param name="name">Name of the <see cref="UnityEngine.GameObject"/>.</param>
+        /// <returns>Name without brackets.</returns>
+        public static string RemoveBracketsOnEndOfName(this string name)
+        {
+            var bracketStart = name.IndexOf('(') - 1;
+
+            if (bracketStart > 0)
+                name = name.Remove(bracketStart, name.Length - bracketStart);
+
+            return name;
+        }
     }
 }

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -11,6 +11,8 @@ namespace Exiled.API.Features
     using System.Collections.ObjectModel;
     using System.Linq;
 
+    using Exiled.API.Extensions;
+
     using LightContainmentZoneDecontamination;
 
     using UnityEngine;
@@ -77,7 +79,10 @@ namespace Exiled.API.Features
             get
             {
                 if (DoorsValue.Count == 0)
+                {
                     DoorsValue.AddRange(Object.FindObjectsOfType<Door>());
+                    DoorTypeExtension.RegisterDoorTypesOnLevelLoad();
+                }
 
                 return ReadOnlyDoorsValue;
             }

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -11,6 +11,7 @@ namespace Exiled.API.Features
     using System.Linq;
 
     using Exiled.API.Enums;
+    using Exiled.API.Extensions;
 
     using UnityEngine;
 
@@ -94,9 +95,7 @@ namespace Exiled.API.Features
         private RoomType FindType(string rawName)
         {
             // Try to remove brackets if they exist.
-            var bracketStart = rawName.IndexOf('(') - 1;
-            if (bracketStart > 0)
-                rawName = rawName.Remove(bracketStart, rawName.Length - bracketStart);
+            rawName = rawName.RemoveBracketsOnEndOfName();
 
             switch (rawName)
             {


### PR DESCRIPTION
Added string extension "RemoveBracketsOnEndOfName" to fix duplicate prefab GameObject names for use with RoomTypes and DoorTypes.
Created an Enum "DoorType" to define the unique Door classes
Created an Extension "Type()" for the Door class which gets the DoorType using GetInstanceId() as a key for a dictiionary populated with Map.Rooms.
Changed the Room.GetDoorType() method to use the new "RemoveBracketsOnEndOfName()" extension.