### PR TITLE
fix a NRE in ghostmode if the server isn't in online mode & update ccm muted bit

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -30,7 +30,8 @@ namespace Exiled.Events.Patches.Events.Player
         {
             try
             {
-                if (!value || string.IsNullOrEmpty(__instance?.UserId))
+                // UserId will always be empty/null if it's not in online mode
+                if (!value || (string.IsNullOrEmpty(__instance.UserId) && CharacterClassManager.OnlineMode))
                     return;
 
                 if (!API.Features.Player.Dictionary.TryGetValue(__instance.gameObject, out API.Features.Player player))
@@ -43,12 +44,12 @@ namespace Exiled.Events.Patches.Events.Player
                 API.Features.Log.SendRaw($"Player {player?.Nickname} ({player?.UserId}) ({player?.Id}) connected with the IP: {player?.IPAddress}", ConsoleColor.Green);
 
                 if (PlayerManager.players.Count >= CustomNetworkManager.slots)
-                    API.Features.Log.Debug($"Server is full!");
+                    API.Features.Log.Debug("Server is full!");
 
                 Timing.CallDelayed(0.25f, () =>
                 {
                     if (player != null && player.IsMuted)
-                        player.ReferenceHub.characterClassManager.SetDirtyBit(1UL);
+                        player.ReferenceHub.characterClassManager.SetDirtyBit(2UL);
                 });
 
                 var ev = new JoinedEventArgs(API.Features.Player.Get(__instance.gameObject));
@@ -57,7 +58,7 @@ namespace Exiled.Events.Patches.Events.Player
             }
             catch (Exception exception)
             {
-                API.Features.Log.Error($"Exiled.Events.Patches.Events.Player.Joined: {exception}\n{exception.StackTrace}");
+                API.Features.Log.Error($"{typeof(Joined).FullName}:\n{exception}");
             }
         }
     }


### PR DESCRIPTION
We'll get a NRE every frame in the ghost mode patch because there's no player & update bit of `CharacterClassManager :: NetworkMuted`.