### PR TITLE
replace Scp173::TurnedPlayers with HashSet

### DIFF
--- a/Exiled.API/Features/Scp173.cs
+++ b/Exiled.API/Features/Scp173.cs
@@ -17,6 +17,6 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a list of player ids who will be turned away from SCP-173.
         /// </summary>
-        public static List<Player> TurnedPlayers { get; private set; } = new List<Player>();
+        public static HashSet<Player> TurnedPlayers { get; } = new HashSet<Player>(20);
     }
 }


### PR DESCRIPTION
Replaced as in Scp096 in favor of performance.

Note: this is a breaking change, all plugins that used it need to be recompiled.