### PR TITLE
Adding pocket dimension room + Fix outside/Map room getter

### DIFF
--- a/Exiled.API/Enums/RoomType.cs
+++ b/Exiled.API/Enums/RoomType.cs
@@ -248,6 +248,11 @@ public enum RoomType
         EzShelter,
 
         /// <summary>
+        /// Pocket Dimension.
+        /// </summary>
+        Pocket,
+
+        /// <summary>
         /// The Surface.
         /// </summary>
         Surface,

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -74,7 +74,7 @@ namespace Exiled.API.Features
                     if (roomTransforms.Count == 0)
                     {
                         ListPool<Transform>.Shared.Return(roomTransforms);
-                        throw new NullReferenceException("Plugin is trying to access Rooms before they are created.");
+                        throw new InvalidOperationException("Plugin is trying to access Rooms before they are created.");
                     }
 
                     // Add the surface transform "room".

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -63,8 +63,6 @@ namespace Exiled.API.Features
             {
                 if (RoomsValue.Count == 0)
                 {
-                    Room.ResetRoomIds();
-
                     List<Transform> roomTransforms = ListPool<Transform>.Shared.Rent();
 
                     // Search for SECTR_Sector instead of tag. It is faster and includes Pocket dimension.

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -231,7 +231,9 @@ namespace Exiled.API.Features
                     return RoomType.EzGateB;
                 case "EZ_Shelter":
                     return RoomType.EzShelter;
-                case "Root_*&*Outside Cams":
+                case "PocketWorld":
+                    return RoomType.Pocket;
+                case "Outside":
                     return RoomType.Surface;
                 default:
                     return RoomType.Unknown;

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -38,15 +38,7 @@ namespace Exiled.API.Features
             Type = FindType(name);
             Doors = FindDoors();
             flickerableLightController = transform.GetComponentInChildren<FlickerableLightController>();
-
-            Id = IdCounter;
-            IdCounter++;
         }
-
-        /// <summary>
-        /// Gets the room's index in <see cref="Map.Rooms"/>.
-        /// </summary>
-        public uint Id { get; }
 
         /// <summary>
         /// Gets the <see cref="Room"/> name.
@@ -83,8 +75,6 @@ namespace Exiled.API.Features
         /// </summary>
         public IEnumerable<Door> Doors { get; }
 
-        private static uint IdCounter { get; set; }
-
         /// <summary>
         /// Equality Comparer.
         /// </summary>
@@ -112,7 +102,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="other">Other Room.</param>
         /// <returns>If the rooms are equal.</returns>
-        public bool Equals(Room other) => other != null && this.Id == other.Id;
+        public bool Equals(Room other) => other != null && this.Transform.gameObject == other.Transform.gameObject;
 
         /// <summary>
         /// Equality Comparer.
@@ -125,12 +115,7 @@ namespace Exiled.API.Features
         /// Gets the unique room Id.
         /// </summary>
         /// <returns>The unique Room Id.</returns>
-        public override int GetHashCode() => Id.GetHashCode();
-
-        /// <summary>
-        /// Used to reset the <see cref="IdCounter"/> to 0 for a new map.
-        /// </summary>
-        internal static void ResetRoomIds() => IdCounter = 0;
+        public override int GetHashCode() => this.Transform.gameObject.GetHashCode();
 
         private static RoomType FindType(string rawName)
         {


### PR DESCRIPTION
Using SECTR_Sector ensures it will get all rooms (Including pocket dimension).
Added error for calling Map.Room before rooms are created.
Added pocket dimension enums and setter for Room.Type().
Fixed the surface transform, need to use "Outside" because that's the correct transform for the surface.