### PR TITLE
Changed Room to component (monobehaviour).

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -35,8 +35,6 @@ namespace Exiled.API.Features
     /// </summary>
     public class Player
     {
-        private static readonly RaycastHit[] CachedGetCurrentRoomRaycast = new RaycastHit[1];
-
         private ReferenceHub referenceHub;
 
         /// <summary>
@@ -669,23 +667,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets the current room the player is in.
         /// </summary>
-        public Room CurrentRoom
-        {
-            get
-            {
-                Ray ray = new Ray(Position, Vector3.down);
-
-                if (Physics.RaycastNonAlloc(ray, CachedGetCurrentRoomRaycast, 10, 1 << 0, QueryTriggerInteraction.Ignore) == 1)
-                {
-                    var room = CachedGetCurrentRoomRaycast[0].collider.gameObject.GetComponentInParent<Room>();
-                    if (room != null)
-                        return room;
-                }
-
-                // Default is surface.
-                return Map.Rooms[Map.Rooms.Count - 1];
-            }
-        }
+        public Room CurrentRoom => Map.FindParentRoom(GameObject);
 
         /// <summary>
         /// Gets or sets the player's group.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -673,23 +673,16 @@ namespace Exiled.API.Features
         {
             get
             {
-                Ray ray = new Ray(Position, Vector3.down); // Shoot down, it's faster.
+                Ray ray = new Ray(Position, Vector3.down);
 
                 if (Physics.RaycastNonAlloc(ray, CachedGetCurrentRoomRaycast, 10, 1 << 0, QueryTriggerInteraction.Ignore) == 1)
                 {
-                    SECTR_Sector sector = CachedGetCurrentRoomRaycast[0].transform.GetComponentInParent<SECTR_Sector>();
-
-                    if (sector != null)
-                    {
-                        foreach (Room room in Map.Rooms)
-                        {
-                            if (room.Transform.gameObject == sector.gameObject)
-                                return room;
-                        }
-                    }
+                    var room = CachedGetCurrentRoomRaycast[0].collider.gameObject.GetComponentInParent<Room>();
+                    if (room != null)
+                        return room;
                 }
 
-                // Default is the surface, since it doesn't have a SECTR_Sector.
+                // Default is surface.
                 return Map.Rooms[Map.Rooms.Count - 1];
             }
         }

--- a/Exiled.API/Features/Room.cs
+++ b/Exiled.API/Features/Room.cs
@@ -7,7 +7,6 @@
 
 namespace Exiled.API.Features
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -19,51 +18,32 @@ namespace Exiled.API.Features
     /// <summary>
     /// The in-game room.
     /// </summary>
-    public class Room : IEquatable<Room>
+    public class Room : MonoBehaviour
     {
-        private readonly FlickerableLightController flickerableLightController;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Room"/> class.
-        /// </summary>
-        /// <param name="name">The room name.</param>
-        /// <param name="transform">The room transform.</param>
-        /// <param name="position">The room position.</param>
-        public Room(string name, Transform transform, Vector3 position)
-        {
-            Name = name;
-            Transform = transform;
-            Position = position;
-            Zone = FindZone();
-            Type = FindType(name);
-            Doors = FindDoors();
-            flickerableLightController = transform.GetComponentInChildren<FlickerableLightController>();
-        }
-
         /// <summary>
         /// Gets the <see cref="Room"/> name.
         /// </summary>
-        public string Name { get; }
+        public string Name => name;
 
         /// <summary>
         /// Gets the <see cref="Room"/> <see cref="UnityEngine.Transform"/>.
         /// </summary>
-        public Transform Transform { get; }
+        public Transform Transform => transform;
 
         /// <summary>
         /// Gets the <see cref="Room"/> position.
         /// </summary>
-        public Vector3 Position { get; }
+        public Vector3 Position => transform.position;
 
         /// <summary>
         /// Gets the <see cref="ZoneType"/> in which the room is located.
         /// </summary>
-        public ZoneType Zone { get; }
+        public ZoneType Zone { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="RoomType"/>.
         /// </summary>
-        public RoomType Type { get; }
+        public RoomType Type { get; private set; }
 
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Player"/> in the <see cref="Room"/>.
@@ -73,49 +53,33 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a <see cref="IEnumerable{T}"/> of <see cref="Door"/> in the <see cref="Room"/>.
         /// </summary>
-        public IEnumerable<Door> Doors { get; }
+        public IEnumerable<Door> Doors { get; private set; }
 
-        /// <summary>
-        /// Equality Comparer.
-        /// </summary>
-        /// <param name="lhs">Left comparer.</param>
-        /// <param name="rhs">Right comparer.</param>
-        /// <returns>If the rooms are equal.</returns>
-        public static bool operator ==(Room lhs, Room rhs) => lhs != null && lhs.Equals(rhs);
-
-        /// <summary>
-        /// Equality Comparer.
-        /// </summary>
-        /// <param name="lhs">Left comparer.</param>
-        /// <param name="rhs">Right comparer.</param>
-        /// <returns>If the rooms are not equal.</returns>
-        public static bool operator !=(Room lhs, Room rhs) => lhs != null && !lhs.Equals(rhs);
+        private FlickerableLightController FlickerableLightController { get; set; }
 
         /// <summary>
         /// Flickers the room's lights off for a duration.
         /// </summary>
         /// <param name="duration">Duration in seconds.</param>
-        public void TurnOffLights(float duration) => flickerableLightController?.ServerFlickerLights(duration);
+        public void TurnOffLights(float duration) => FlickerableLightController?.ServerFlickerLights(duration);
 
         /// <summary>
-        /// Equality Comparer.
+        /// Factory method to create and add a <see cref="Room"/> component to a Transform.
+        /// We can add parameters to be set privately here.
         /// </summary>
-        /// <param name="other">Other Room.</param>
-        /// <returns>If the rooms are equal.</returns>
-        public bool Equals(Room other) => other != null && this.Transform.gameObject == other.Transform.gameObject;
+        /// <param name="roomGameObject">The Game Object to attach the Room component to.</param>
+        /// <returns>The Room component that was instantiated onto the Game Object.</returns>
+        internal static Room CreateComponent(GameObject roomGameObject)
+        {
+            var room = roomGameObject.AddComponent<Room>();
 
-        /// <summary>
-        /// Equality Comparer.
-        /// </summary>
-        /// <param name="obj">Other object.</param>
-        /// <returns>If the rooms are equal.</returns>
-        public override bool Equals(object obj) => obj is Room room && this == room;
+            room.Zone = FindZone(roomGameObject);
+            room.Type = FindType(roomGameObject.name);
+            room.Doors = FindDoors(roomGameObject);
+            room.FlickerableLightController = roomGameObject.GetComponentInChildren<FlickerableLightController>();
 
-        /// <summary>
-        /// Gets the unique room Id.
-        /// </summary>
-        /// <returns>The unique Room Id.</returns>
-        public override int GetHashCode() => this.Transform.gameObject.GetHashCode();
+            return room;
+        }
 
         private static RoomType FindType(string rawName)
         {
@@ -225,12 +189,14 @@ namespace Exiled.API.Features
             }
         }
 
-        private ZoneType FindZone()
+        private static ZoneType FindZone(GameObject gameObject)
         {
-            if (Transform.parent == null)
+            var transform = gameObject.transform;
+
+            if (transform.parent == null)
                 return ZoneType.Unspecified;
 
-            switch (Transform.parent.name)
+            switch (transform.parent.name)
             {
                 case "HeavyRooms":
                     return ZoneType.HeavyContainment;
@@ -239,18 +205,18 @@ namespace Exiled.API.Features
                 case "EntranceRooms":
                     return ZoneType.Entrance;
                 default:
-                    return Position.y > 900 ? ZoneType.Surface : ZoneType.Unspecified;
+                    return transform.position.y > 900 ? ZoneType.Surface : ZoneType.Unspecified;
             }
         }
 
-        private List<Door> FindDoors()
+        private static List<Door> FindDoors(GameObject gameObject)
         {
             List<Door> doorList = new List<Door>();
             foreach (Scp079Interactable scp079Interactable in Interface079.singleton.allInteractables)
             {
                 foreach (Scp079Interactable.ZoneAndRoom zoneAndRoom in scp079Interactable.currentZonesAndRooms)
                 {
-                    if (zoneAndRoom.currentRoom == Name && zoneAndRoom.currentZone == Transform.parent.name)
+                    if (zoneAndRoom.currentRoom == gameObject.name && zoneAndRoom.currentZone == gameObject.transform.parent.name)
                     {
                         if (scp079Interactable.type == Scp079Interactable.InteractableType.Door)
                         {

--- a/Exiled.Events/Patches/Events/Scp079/Interacting.cs
+++ b/Exiled.Events/Patches/Events/Scp079/Interacting.cs
@@ -12,12 +12,18 @@ namespace Exiled.Events.Patches.Events.Scp079
 #pragma warning disable CS0436
     using System;
     using System.Collections.Generic;
+
     using Exiled.API.Features;
     using Exiled.Events.EventArgs;
+
     using GameCore;
+
     using HarmonyLib;
+
     using NorthwoodLib.Pools;
+
     using UnityEngine;
+
     using Console = GameCore.Console;
     using Log = Exiled.API.Features.Log;
 
@@ -179,10 +185,8 @@ namespace Exiled.Events.Patches.Events.Scp079
                                 break;
                             }
 
-                            Transform roomTransform = scp079SpeakerObject.transform.parent;
-
                             Player player = Player.Get(__instance.gameObject);
-                            Room room = new Room(roomTransform.name, roomTransform.transform, roomTransform.position);
+                            Room room = Map.FindParentRoom(__instance.currentCamera.gameObject);
 
                             float apDrain = __instance.GetManaFromLabel("Speaker Start", __instance.abilities);
                             bool isAllowed = apDrain * 1.5f <= __instance.curMana;
@@ -225,11 +229,11 @@ namespace Exiled.Events.Patches.Events.Scp079
                             }
 
                             string[] array7 = __instance.Speaker.Substring(0, __instance.Speaker.Length - 14).Split('/');
-                            GameObject roomObject = GameObject.Find(array7[0] + "/" + array7[1]);
 
                             StoppingSpeakerEventArgs ev = new StoppingSpeakerEventArgs(
                                 Player.Get(__instance.gameObject),
-                                new Room(roomObject.name, roomObject.transform, roomObject.transform.position));
+                                Map.FindParentRoom(__instance.currentCamera.gameObject));
+
                             Handlers.Scp079.OnStoppingSpeaker(ev);
 
                             if (ev.IsAllowed)


### PR DESCRIPTION
+Fixed lookup for Rooms, this should get -all- the rooms a player can possibly be in.
+Added public method "Map.FindParentRoom(GameObject)" An easy and efficient way to get the room for any game object inside of a room, including players and pickups.