### PR TITLE
Added a ForceCuff check in InteractingElevators

### DIFF
--- a/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingElevator.cs
@@ -29,7 +29,7 @@ namespace Exiled.Events.Patches.Events.Player
             try
             {
                 if (!__instance._playerInteractRateLimit.CanExecute(true) ||
-                    (__instance._hc.CufferId > 0 && !PlayerInteract.CanDisarmedInteract) || elevator == null)
+                    ((__instance._hc.CufferId > 0 || __instance._hc.ForceCuff) && !PlayerInteract.CanDisarmedInteract) || elevator == null)
                     return false;
 
                 Lift component = elevator.GetComponent<Lift>();


### PR DESCRIPTION
Added a ForceCuff check in the InteractingElevators patch.
Players can't interact with elevators if they're cuffed (forced or not) and PlayerInteract.CanDisarmedInteract = false