### PR TITLE
Corrected the listed SCP in Portal event

### DIFF
--- a/Exiled.Events/EventArgs/CreatingPortalEventArgs.cs
+++ b/Exiled.Events/EventArgs/CreatingPortalEventArgs.cs
@@ -32,7 +32,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the player who's controlling SCP-096.
+        /// Gets the player who's controlling SCP-106.
         /// </summary>
         public Player Player { get; }
 


### PR DESCRIPTION
In CreatingPortalEventArgs, the listed SCP for ev.Player is SCP-096 instead of SCP-106.