### PR TITLE
Adding Map::SpawnedItem

### DIFF
--- a/Exiled.Events/EventArgs/SpawnedItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawnedItemEventArgs.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpawnedItemEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    /// <summary>
+    /// Contains all informations after the server spawns an item.
+    /// </summary>
+    public class SpawnedItemEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpawnedItemEventArgs"/> class.
+        /// </summary>
+        /// <param name="pickup"><inheritdoc cref="Pickup"/></param>
+        public SpawnedItemEventArgs(Pickup pickup)
+        {
+            Pickup = pickup;
+        }
+
+        /// <summary>
+        /// Gets or sets the item pickup.
+        /// </summary>
+        public Pickup Pickup { get; set; }
+    }
+}

--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpawningItemEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Exiled.API.Features;
+
+    using UnityEngine;
+
+    /// <summary>
+    /// Contains all informations before the server spawns an item.
+    /// </summary>
+    public class SpawningItemEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpawningItemEventArgs"/> class.
+        /// </summary>
+        /// <param name="id"><inheritdoc cref="Id"/></param>
+        /// <param name="pos"><inheritdoc cref="Position"/></param>
+        /// <param name="rot"><inheritdoc cref="Rotation"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public SpawningItemEventArgs(ItemType id, Vector3 pos, Quaternion rot, bool isAllowed = true)
+        {
+            Id = id;
+            Position = pos;
+            Rotation = rot;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets or sets the item to be dropped.
+        /// </summary>
+        public ItemType Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the position to spawn the item.
+        /// </summary>
+        public Vector3 Position { get; set; }
+
+        /// <summary>
+        /// Gets or sets the rotation to spawn the item.
+        /// </summary>
+        public Quaternion Rotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the event can be executed or not.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -25,12 +25,14 @@ namespace Exiled.Events.EventArgs
         /// <param name="id"><inheritdoc cref="Id"/></param>
         /// <param name="pos"><inheritdoc cref="Position"/></param>
         /// <param name="rot"><inheritdoc cref="Rotation"/></param>
+        /// <param name="locked"><inheritdoc cref="Locked"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public SpawningItemEventArgs(ItemType id, Vector3 pos, Quaternion rot, bool isAllowed = true)
+        public SpawningItemEventArgs(ItemType id, Vector3 pos, Quaternion rot, bool locked, bool isAllowed = true)
         {
             Id = id;
             Position = pos;
             Rotation = rot;
+            Locked = locked;
             IsAllowed = isAllowed;
         }
 
@@ -48,6 +50,11 @@ namespace Exiled.Events.EventArgs
         /// Gets or sets the rotation to spawn the item.
         /// </summary>
         public Quaternion Rotation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the Pickup will be locked.
+        /// </summary>
+        public bool Locked { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the event can be executed or not.

--- a/Exiled.Events/Handlers/Map.cs
+++ b/Exiled.Events/Handlers/Map.cs
@@ -68,6 +68,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<SpawningItemEventArgs> SpawningItem;
 
         /// <summary>
+        /// Invoked after an item is spawned.
+        /// </summary>
+        public static event CustomEventHandler<SpawnedItemEventArgs> SpawnedItem;
+
+        /// <summary>
         /// Called before placing a decal.
         /// </summary>
         /// <param name="ev">The <see cref="PlacingDecalEventArgs"/> instance.</param>
@@ -126,5 +131,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="SpawningItemEventArgs"/> instance.</param>
         public static void OnSpawningItem(SpawningItemEventArgs ev) => SpawningItem.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after an item is spawned.
+        /// </summary>
+        /// <param name="ev">The <see cref="SpawnedItemEventArgs"/> instance.</param>
+        public static void OnSpawnedItem(SpawnedItemEventArgs ev) => SpawnedItem.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Handlers/Map.cs
+++ b/Exiled.Events/Handlers/Map.cs
@@ -63,6 +63,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ExplodingGrenadeEventArgs> ExplodingGrenade;
 
         /// <summary>
+        /// Invoked before an item is spawned.
+        /// </summary>
+        public static event CustomEventHandler<SpawningItemEventArgs> SpawningItem;
+
+        /// <summary>
         /// Called before placing a decal.
         /// </summary>
         /// <param name="ev">The <see cref="PlacingDecalEventArgs"/> instance.</param>
@@ -115,5 +120,11 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="ExplodingGrenadeEventArgs"/> instance.</param>
         public static void OnExplodingGrenade(ExplodingGrenadeEventArgs ev) => ExplodingGrenade.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before an item is spawned.
+        /// </summary>
+        /// <param name="ev">The <see cref="SpawningItemEventArgs"/> instance.</param>
+        public static void OnSpawningItem(SpawningItemEventArgs ev) => SpawningItem.InvokeSafely(ev);
     }
 }

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -21,7 +21,7 @@ namespace Exiled.Events.Patches.Events.Map
 
     /// <summary>
     /// Patches <see cref="RandomItemSpawner.SpawnerItemToSpawn.DoorTrigger"/>.
-    /// Adds the <see cref="Handlers.Map.SpawningItem"/> event.
+    /// Adds the <see cref="Handlers.Map.SpawningItem"/> and <see cref="Handlers.Map.SpawnedItem"/> events.
     /// </summary>
     [HarmonyPatch(typeof(RandomItemSpawner.SpawnerItemToSpawn), nameof(RandomItemSpawner.SpawnerItemToSpawn.Spawn))]
     internal static class SpawningItem
@@ -40,6 +40,9 @@ namespace Exiled.Events.Patches.Events.Map
                 pickup.RefreshDurability(true, true);
                 if (ev.Locked)
                     pickup.Locked = true;
+
+                SpawnedItemEventArgs spawned_ev = new SpawnedItemEventArgs(pickup);
+                Handlers.Map.OnSpawnedItem(spawned_ev);
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -26,7 +26,7 @@ namespace Exiled.Events.Patches.Events.Map
     [HarmonyPatch(typeof(RandomItemSpawner.SpawnerItemToSpawn), nameof(RandomItemSpawner.SpawnerItemToSpawn.Spawn))]
     internal static class SpawningItem
     {
-        private static IEnumerator<float> Prefix(RandomItemSpawner.SpawnerItemToSpawn __instance)
+        private static IEnumerator<float> Postfix(IEnumerator<float> values, RandomItemSpawner.SpawnerItemToSpawn __instance)
         {
             SpawningItemEventArgs ev = new SpawningItemEventArgs(__instance._id, __instance._pos, __instance._rot, __instance._locked, true);
 

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -23,7 +23,7 @@ namespace Exiled.Events.Patches.Events.Map
     [HarmonyPatch(typeof(RandomItemSpawner.SpawnerItemToSpawn), nameof(RandomItemSpawner.SpawnerItemToSpawn.DoorTrigger))]
     internal static class SpawningItem
     {
-        public static bool Prefix(RandomItemSpawner.SpawnerItemToSpawn __instance)
+        private static bool Prefix(RandomItemSpawner.SpawnerItemToSpawn __instance)
         {
             SpawningItemEventArgs ev = new SpawningItemEventArgs(__instance._id, __instance._pos, __instance._rot, true);
 

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -28,7 +28,7 @@ namespace Exiled.Events.Patches.Events.Map
     {
         private static IEnumerator<float> Prefix(RandomItemSpawner.SpawnerItemToSpawn __instance)
         {
-            SpawningItemEventArgs ev = new SpawningItemEventArgs(__instance._id, __instance._pos, __instance._rot, true);
+            SpawningItemEventArgs ev = new SpawningItemEventArgs(__instance._id, __instance._pos, __instance._rot, __instance._locked, true);
 
             Handlers.Map.OnSpawningItem(ev);
 
@@ -38,7 +38,7 @@ namespace Exiled.Events.Patches.Events.Map
                 yield return float.NegativeInfinity;
                 HostItemSpawner.SetPos(pickup, ev.Position, ev.Id, ev.Rotation.eulerAngles);
                 pickup.RefreshDurability(true, true);
-                if (__instance._locked)
+                if (ev.Locked)
                     pickup.Locked = true;
             }
         }

--- a/Exiled.Events/Patches/Events/Map/SpawningItem.cs
+++ b/Exiled.Events/Patches/Events/Map/SpawningItem.cs
@@ -1,0 +1,41 @@
+// -----------------------------------------------------------------------
+// <copyright file="SpawningItem.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Map
+{
+#pragma warning disable SA1313
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    using MEC;
+
+    /// <summary>
+    /// Patches <see cref="RandomItemSpawner.SpawnerItemToSpawn.DoorTrigger"/>.
+    /// Adds the <see cref="Handlers.Map.SpawningItem"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(RandomItemSpawner.SpawnerItemToSpawn), nameof(RandomItemSpawner.SpawnerItemToSpawn.DoorTrigger))]
+    internal static class SpawningItem
+    {
+        public static bool Prefix(RandomItemSpawner.SpawnerItemToSpawn __instance)
+        {
+            SpawningItemEventArgs ev = new SpawningItemEventArgs(__instance._id, __instance._pos, __instance._rot, true);
+
+            Handlers.Map.OnSpawningItem(ev);
+
+            if (!ev.IsAllowed)
+                return false;
+            if (ev.Id == __instance._id && ev.Position == __instance._pos && ev.Rotation == __instance._rot)
+                return true;
+            RandomItemSpawner.SpawnerItemToSpawn newItem = new RandomItemSpawner.SpawnerItemToSpawn(ev.Id, ev.Position, ev.Rotation, __instance._locked);
+            Timing.RunCoroutine(newItem.Spawn(), Segment.FixedUpdate);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
* New event: `Map::SpawnedItem` - Fires directly after an item is spawned, event args contains the item's pickup.