### PR TITLE
Additions to `Scp096::StartPrying` & `Scp096::AddingTarget` & `Scp049::FinishingRecall` & `Scp049::StartingRecall` events

### DIFF
--- a/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
@@ -11,6 +11,8 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Features;
 
+    using Scp096 = PlayableScps.Scp096;
+
     /// <summary>
     /// Contains all informations before adding a target to SCP-096.
     /// </summary>
@@ -20,11 +22,13 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="AddingTargetEventArgs"/> class.
         /// </summary>
         /// <param name="scp096"><see cref="Player"/> who is SCP-096.</param>
+        /// <param name="player">The player who is playing as SCP-096.</param>
         /// <param name="target"><see cref="Player"/> who is the target to be added.</param>
         /// <param name="ahpToAdd"><see cref="int"/> amount of temporary health to add to <see cref="Scp096"/>.</param>
         /// <param name="enrageTimeToAdd"><see cref="float"/> amount of time to add to <see cref="Scp096"/>'s enrage timer. Note: This does not affect anything if he doesn't already have any targets before this event is called.</param>
-        public AddingTargetEventArgs(Player scp096, Player target, int ahpToAdd, float enrageTimeToAdd)
+        public AddingTargetEventArgs(Scp096 scp096, Player player, Player target, int ahpToAdd, float enrageTimeToAdd)
         {
+            Player = player;
             Scp096 = scp096;
             Target = target;
             AhpToAdd = ahpToAdd;
@@ -32,12 +36,17 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the <see cref="Player"/> object of the SCP-096.
+        /// Gets the player who is playing SCP-096.
         /// </summary>
-        public Player Scp096 { get; }
+        public Player Player { get; }
 
         /// <summary>
-        /// Gets the <see cref="Player"/> being added as a target.
+        /// Gets the Scp096 object.
+        /// </summary>
+        public Scp096 Scp096 { get; }
+
+        /// <summary>
+        /// Gets the player being added as a target.
         /// </summary>
         public Player Target { get; }
 

--- a/Exiled.Events/EventArgs/FinishingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/FinishingRecallEventArgs.cs
@@ -11,6 +11,8 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Features;
 
+    using Scp049 = PlayableScps.Scp049;
+
     /// <summary>
     /// Contains all informations before SCP-049 finishes recalling a player.
     /// </summary>
@@ -19,15 +21,22 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="FinishingRecallEventArgs"/> class.
         /// </summary>
-        /// <param name="target"><inheritdoc cref="Target"/></param>
         /// <param name="scp049"><inheritdoc cref="Scp049"/></param>
+        /// <param name="target"><inheritdoc cref="Target"/></param>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public FinishingRecallEventArgs(Player target, Player scp049, bool isAllowed = true)
+        public FinishingRecallEventArgs(Scp049 scp049, Player target, Player player, bool isAllowed = true)
         {
             Target = target;
             Scp049 = scp049;
+            Player = player;
             IsAllowed = isAllowed;
         }
+
+        /// <summary>
+        /// Gets the Scp049 object.
+        /// </summary>
+        public Scp049 Scp049 { get; }
 
         /// <summary>
         /// Gets the player who's getting infected.
@@ -35,9 +44,9 @@ namespace Exiled.Events.EventArgs
         public Player Target { get; }
 
         /// <summary>
-        /// Gets the player who is SCP049.
+        /// Gets the player who is SCP-049.
         /// </summary>
-        public Player Scp049 { get; }
+        public Player Player { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the event can be executed or not.

--- a/Exiled.Events/EventArgs/StartPryingGateEventArgs.cs
+++ b/Exiled.Events/EventArgs/StartPryingGateEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs
     using System;
 
     using Exiled.API.Features;
+    using Scp096 = PlayableScps.Scp096;
 
     /// <summary>
     /// Contains all information before SCP-096 starts prying a gate open.
@@ -20,15 +21,22 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="StartPryingGateEventArgs"/> class.
         /// </summary>
         /// <param name="scp096">The Scp096 who is triggering the event.</param>
+        /// <param name="player">The player that is playing SCP-096.</param>
         /// <param name="gate">The gate to be pried open.</param>
-        public StartPryingGateEventArgs(Player scp096, Door gate)
+        public StartPryingGateEventArgs(Scp096 scp096, Player player, Door gate)
         {
-            Player = scp096;
+            Scp096 = scp096;
+            Player = player;
             Gate = gate;
         }
 
         /// <summary>
-        /// Gets the <see cref="Player"/> object of the SCP-096.
+        /// Gets the Scp096 object.
+        /// </summary>
+        public Scp096 Scp096 { get; }
+
+        /// <summary>
+        /// Gets the player who is playing SCP-096.
         /// </summary>
         public Player Player { get; }
 

--- a/Exiled.Events/EventArgs/StartingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/StartingRecallEventArgs.cs
@@ -11,6 +11,8 @@ namespace Exiled.Events.EventArgs
 
     using Exiled.API.Features;
 
+    using Scp049 = PlayableScps.Scp049;
+
     /// <summary>
     /// Contains all informations before SCP-049 begins recalling a player.
     /// </summary>
@@ -19,15 +21,22 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="StartingRecallEventArgs"/> class.
         /// </summary>
-        /// <param name="target"><inheritdoc cref="Target"/></param>
         /// <param name="scp049"><inheritdoc cref="Scp049"/></param>
+        /// <param name="target"><inheritdoc cref="Target"/></param>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public StartingRecallEventArgs(Player target, Player scp049, bool isAllowed = true)
+        public StartingRecallEventArgs(Scp049 scp049, Player target, Player player, bool isAllowed = true)
         {
             Target = target;
             Scp049 = scp049;
+            Player = player;
             IsAllowed = isAllowed;
         }
+
+        /// <summary>
+        /// Gets the Scp049 object.
+        /// </summary>
+        public Scp049 Scp049 { get; }
 
         /// <summary>
         /// Gets the player who's getting infected.
@@ -35,9 +44,9 @@ namespace Exiled.Events.EventArgs
         public Player Target { get; }
 
         /// <summary>
-        /// Gets the player who is SCP049.
+        /// Gets the player who is SCP-049.
         /// </summary>
-        public Player Scp049 { get; }
+        public Player Player { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the event can be executed or not.

--- a/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
+++ b/Exiled.Events/Patches/Events/Scp049/StartingAndFinishingRecall.cs
@@ -92,7 +92,7 @@ namespace Exiled.Events.Patches.Events.Scp049
                                 break;
                             }
 
-                            var ev = new StartingRecallEventArgs(API.Features.Player.Get(referenceHub2.gameObject), API.Features.Player.Get(__instance.Hub.gameObject));
+                            var ev = new StartingRecallEventArgs(__instance, API.Features.Player.Get(referenceHub2.gameObject), API.Features.Player.Get(__instance.Hub.gameObject));
 
                             Handlers.Scp049.OnStartingRecall(ev);
 
@@ -148,7 +148,7 @@ namespace Exiled.Events.Patches.Events.Scp049
                                 return false;
                             }
 
-                            var ev = new FinishingRecallEventArgs(API.Features.Player.Get(referenceHub.gameObject), API.Features.Player.Get(__instance.Hub.gameObject));
+                            var ev = new FinishingRecallEventArgs(__instance, API.Features.Player.Get(referenceHub.gameObject), API.Features.Player.Get(__instance.Hub.gameObject));
 
                             Handlers.Scp049.OnFinishingRecall(ev);
 

--- a/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
+++ b/Exiled.Events/Patches/Events/Scp096/AddingTarget.cs
@@ -47,7 +47,7 @@ namespace Exiled.Events.Patches.Events.Scp096
                 return true;
             }
 
-            AddingTargetEventArgs ev = new AddingTargetEventArgs(scp096, targetPlayer, 70, __instance.EnrageTimePerReset);
+            AddingTargetEventArgs ev = new AddingTargetEventArgs(__instance, scp096, targetPlayer, 70, __instance.EnrageTimePerReset);
             Exiled.Events.Handlers.Scp096.OnAddingTarget(ev);
             if (ev.IsAllowed)
             {

--- a/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
+++ b/Exiled.Events/Patches/Events/Scp096/StartPryingGate.cs
@@ -25,7 +25,7 @@ namespace Exiled.Events.Patches.Events.Scp096
         {
             if (__instance.Charging && __instance.Enraged && (!gate.isOpen && gate.doorType == Door.DoorTypes.HeavyGate))
             {
-                var ev = new StartPryingGateEventArgs(API.Features.Player.Get(__instance.Hub.gameObject), gate);
+                var ev = new StartPryingGateEventArgs(__instance, API.Features.Player.Get(__instance.Hub.gameObject), gate);
                 Exiled.Events.Handlers.Scp096.OnStartPryingGate(ev);
                 return ev.IsAllowed;
             }


### PR DESCRIPTION
* Adding `Round::ForceSpawnTeam(SpawnableTeamType team, bool spawnVehicle = false)` - Quick way to spawn a reinforcement team.