### PR TITLE
Fixing up lots of summaries

### DIFF
--- a/Exiled.API/Enums/AmmoType.cs
+++ b/Exiled.API/Enums/AmmoType.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="AmmoType.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -19,7 +19,7 @@ namespace Exiled.API.Enums
         Nato556,
 
         /// <summary>
-        /// 7.62mm mm Ammunition.
+        /// 7.62mm Ammunition.
         /// Used by <see cref="ItemType.GunMP7"/> and <see cref="ItemType.GunLogicer"/>.
         /// </summary>
         Nato762,

--- a/Exiled.API/Enums/LeadingTeam.cs
+++ b/Exiled.API/Enums/LeadingTeam.cs
@@ -8,7 +8,7 @@
 namespace Exiled.API.Enums
 {
     /// <summary>
-    /// The team that is winning the round.
+    /// The team that is currently leading the round.
     /// </summary>
     public enum LeadingTeam : byte
     {
@@ -18,12 +18,12 @@ namespace Exiled.API.Enums
         FacilityForces,
 
         /// <summary>
-        /// Represents Class D and Chaos Insurgency.
+        /// Represents Class-D and Chaos Insurgency.
         /// </summary>
         ChaosInsurgency,
 
         /// <summary>
-        /// Represents SCP.
+        /// Represents SCPs.
         /// </summary>
         Anomalies,
 

--- a/Exiled.API/Features/Cassie.cs
+++ b/Exiled.API/Features/Cassie.cs
@@ -17,7 +17,7 @@ namespace Exiled.API.Features
     public static class Cassie
     {
         /// <summary>
-        /// Gets a value indicating whether or not a C.A.S.S.I.E announcement is currently playing. Does not include decontamination messages.
+        /// Gets a value indicating whether or not a C.A.S.S.I.E announcement is currently playing or if a C.A.S.S.I.E announcement is queued. Does not include decontamination messages.
         /// </summary>
         public static bool IsSpeaking => !NineTailedFoxAnnouncer.singleton.Free;
 
@@ -33,7 +33,7 @@ namespace Exiled.API.Features
         /// Reproduce a C.A.S.S.I.E message after a certain amount of seconds.
         /// </summary>
         /// <param name="message">The message to be reproduced.</param>
-        /// <param name="delay">The seconds that have to pass, before reproducing the message.</param>
+        /// <param name="delay">The seconds that have to pass before reproducing the message.</param>
         /// <param name="isHeld">Indicates whether C.A.S.S.I.E has to hold the message.</param>
         /// <param name="isNoisy">Indicates whether C.A.S.S.I.E has to make noises or not during the message.</param>
         public static void DelayedMessage(string message, float delay, bool isHeld = false, bool isNoisy = true)

--- a/Exiled.API/Features/Cassie.cs
+++ b/Exiled.API/Features/Cassie.cs
@@ -17,7 +17,7 @@ namespace Exiled.API.Features
     public static class Cassie
     {
         /// <summary>
-        /// Gets a value indicating whether or not a C.A.S.S.I.E announcement is currently playing or if a C.A.S.S.I.E announcement is queued. Does not include decontamination messages.
+        /// Gets a value indicating whether or not a C.A.S.S.I.E announcement is currently playing. Does not include decontamination messages.
         /// </summary>
         public static bool IsSpeaking => !NineTailedFoxAnnouncer.singleton.Free;
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -24,7 +24,7 @@ namespace Exiled.API.Features
     using Object = UnityEngine.Object;
 
     /// <summary>
-    /// A set of tools to handle the in-game map more easily.
+    /// A set of tools to easily handle the in-game map.
     /// </summary>
     public static class Map
     {
@@ -43,7 +43,7 @@ namespace Exiled.API.Features
         private static SpawnpointManager spawnpointManager;
 
         /// <summary>
-        /// Gets a value indicating whether the decontamination has been completed or not.
+        /// Gets a value indicating whether decontamination has begun in light containment.
         /// </summary>
         public static bool IsLCZDecontaminated => DecontaminationController.Singleton._stopUpdating;
 
@@ -53,7 +53,7 @@ namespace Exiled.API.Features
         public static int ActivatedGenerators => Generator079.mainGenerator.totalVoltage;
 
         /// <summary>
-        /// Gets all cameras of SCP-079.
+        /// Gets all SCP-079 cameras.
         /// </summary>
         public static Camera079[] Cameras => Scp079PlayerScript.allCameras;
 
@@ -207,7 +207,7 @@ namespace Exiled.API.Features
         /// </summary>
         /// <param name="position">Hands position.</param>
         /// <param name="rotation">Hands rotation.</param>
-        [Obsolete("Was removed", true)]
+        [Obsolete("This API was removed with SCP-330 and is no longer available.", true)]
         public static void SpawnHands(Vector3 position, Quaternion rotation)
         {
         }
@@ -261,7 +261,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Starts the Decontamination process.
+        /// Starts the light containment decontamination process.
         /// </summary>
         public static void StartDecontamination()
         {
@@ -277,7 +277,7 @@ namespace Exiled.API.Features
         public static void TurnOffAllLights(float duration, bool isHeavyContainmentZoneOnly = false) => Generator079.Generators[0].ServerOvercharge(duration, isHeavyContainmentZoneOnly);
 
         /// <summary>
-        ///     Clears the lazy loading game object cache.
+        /// Clears the lazy loading game object cache.
         /// </summary>
         internal static void ClearCache()
         {

--- a/Exiled.API/Features/Scp096.cs
+++ b/Exiled.API/Features/Scp096.cs
@@ -10,12 +10,12 @@ namespace Exiled.API.Features
     using System.Collections.Generic;
 
     /// <summary>
-    /// Represents the general role of Scp096.
+    /// A set of tools to modify SCP-096's behaviour.
     /// </summary>
     public static class Scp096
     {
         /// <summary>
-        /// Gets or Sets a value indicating the max shield amount Scp096 can have.
+        /// Gets or Sets a value indicating the max shield amount SCP-096 can have during his docile state.
         /// </summary>
         public static float MaxShield { get; set; } = 350;
 

--- a/Exiled.API/Features/Scp914.cs
+++ b/Exiled.API/Features/Scp914.cs
@@ -14,7 +14,7 @@ namespace Exiled.API.Features
     using Mirror;
 
     using UnityEngine;
-    
+
     using Utils.ConfigHandler;
 
     /// <summary>

--- a/Exiled.API/Features/Scp914.cs
+++ b/Exiled.API/Features/Scp914.cs
@@ -14,11 +14,11 @@ namespace Exiled.API.Features
     using Mirror;
 
     using UnityEngine;
-
+    
     using Utils.ConfigHandler;
 
     /// <summary>
-    /// A set of tools to use the Scp914 machine more easily.
+    /// A set of tools to modify SCP-914's behaviour.
     /// </summary>
     public static class Scp914
     {

--- a/Exiled.API/Features/Server.cs
+++ b/Exiled.API/Features/Server.cs
@@ -12,7 +12,7 @@ namespace Exiled.API.Features
     using Mirror;
 
     /// <summary>
-    /// A set of tools to work with the server code more easily .
+    /// A set of tools to easily work with the server.
     /// </summary>
     public static class Server
     {

--- a/Exiled.API/Features/Warhead.cs
+++ b/Exiled.API/Features/Warhead.cs
@@ -10,7 +10,7 @@ namespace Exiled.API.Features
     using System;
 
     /// <summary>
-    /// A set of tools to work with the warhead code more easily.
+    /// A set of tools to easily work with the alpha warhead.
     /// </summary>
     public static class Warhead
     {

--- a/Exiled.Events/EventArgs/ActivatingWorkstationEventArgs.cs
+++ b/Exiled.Events/EventArgs/ActivatingWorkstationEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player activates the workstation.
+    /// Contains all informations before a player activates a workstation.
     /// </summary>
     public class ActivatingWorkstationEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
+++ b/Exiled.Events/EventArgs/AddingTargetEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all information before adding a target to SCP-096.
+    /// Contains all informations before adding a target to SCP-096.
     /// </summary>
     public class AddingTargetEventArgs : EventArgs
     {
@@ -42,7 +42,7 @@ namespace Exiled.Events.EventArgs
         public Player Target { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether gets or sets whether or not the target is allowed to be added.
+        /// Gets or sets a value indicating whether or not the target is allowed to be added.
         /// </summary>
         public bool IsAllowed { get; set; } = true;
 

--- a/Exiled.Events/EventArgs/AnnouncingNtfEntranceEventArgs.cs
+++ b/Exiled.Events/EventArgs/AnnouncingNtfEntranceEventArgs.cs
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using System;
 
     /// <summary>
-    /// Contains all informations before announcing the ntf entrance.
+    /// Contains all informations before announcing the NTF entrance.
     /// </summary>
     public class AnnouncingNtfEntranceEventArgs : EventArgs
     {
@@ -30,7 +30,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the number of scps left.
+        /// Gets the number of SCPs left.
         /// </summary>
         public int ScpsLeft { get; }
 

--- a/Exiled.Events/EventArgs/BanningEventArgs.cs
+++ b/Exiled.Events/EventArgs/BanningEventArgs.cs
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before banning a player.
+    /// Contains all informations before banning a player from the server.
     /// </summary>
     public class BanningEventArgs : KickingEventArgs
     {

--- a/Exiled.Events/EventArgs/ChangingItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingItemEventArgs.cs
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player changes the item in his hand.
+    /// Contains all informations before a player's held item changes.
     /// </summary>
     public class ChangingItemEventArgs : System.EventArgs
     {

--- a/Exiled.Events/EventArgs/ChangingKnobSettingEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingKnobSettingEventArgs.cs
@@ -14,7 +14,7 @@ namespace Exiled.Events.EventArgs
     using global::Scp914;
 
     /// <summary>
-    /// Contains all informations before changing the SCP-914 knob setting.
+    /// Contains all informations before a player changes the SCP-914 knob setting.
     /// </summary>
     public class ChangingKnobSettingEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/CreatingPortalEventArgs.cs
+++ b/Exiled.Events/EventArgs/CreatingPortalEventArgs.cs
@@ -14,7 +14,7 @@ namespace Exiled.Events.EventArgs
     using UnityEngine;
 
     /// <summary>
-    /// Contains all informations before creating a portal with SCP-096.
+    /// Contains all informations before SCP-106 creates a portal.
     /// </summary>
     public class CreatingPortalEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/DeactivatingWorkstationEventArgs.cs
+++ b/Exiled.Events/EventArgs/DeactivatingWorkstationEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player activates the workstation.
+    /// Contains all informations before a player deactivates a workstation.
     /// </summary>
     public class DeactivatingWorkstationEventArgs : ActivatingWorkstationEventArgs
     {

--- a/Exiled.Events/EventArgs/DecontaminatingEventArgs.cs
+++ b/Exiled.Events/EventArgs/DecontaminatingEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="DecontaminatingEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.

--- a/Exiled.Events/EventArgs/DyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/DyingEventArgs.cs
@@ -47,7 +47,7 @@ namespace Exiled.Events.EventArgs
         public PlayerStats.HitInfo HitInformation { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether gets or sets if the player should be killed or not.
+        /// Gets or sets a value indicating whether or not the player should be killed.
         /// </summary>
         public bool IsAllowed { get; set; }
     }

--- a/Exiled.Events/EventArgs/EjectingGeneratorTabletEventArgs.cs
+++ b/Exiled.Events/EventArgs/EjectingGeneratorTabletEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="EjectingGeneratorTabletEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player ejects a tablet.
+    /// Contains all informations before a player ejects a tablet from a generator.
     /// </summary>
     public class EjectingGeneratorTabletEventArgs : InsertingGeneratorTabletEventArgs
     {

--- a/Exiled.Events/EventArgs/EscapingEventArgs.cs
+++ b/Exiled.Events/EventArgs/EscapingEventArgs.cs
@@ -35,7 +35,7 @@ namespace Exiled.Events.EventArgs
         public Player Player { get; }
 
         /// <summary>
-        /// Gets or sets the new player's role, assigned after escaping.
+        /// Gets or sets the role that will be assigned when the player escapes.
         /// </summary>
         public RoleType NewRole { get; set; }
 

--- a/Exiled.Events/EventArgs/EscapingPocketDimensionEventArgs.cs
+++ b/Exiled.Events/EventArgs/EscapingPocketDimensionEventArgs.cs
@@ -37,7 +37,7 @@ namespace Exiled.Events.EventArgs
         public Player Player { get; }
 
         /// <summary>
-        /// Gets or sets the position in which the player is going to be teleported.
+        /// Gets or sets the position in which the player is going to be teleported to.
         /// </summary>
         public Vector3 TeleportPosition { get; set; }
 

--- a/Exiled.Events/EventArgs/ExplodingGrenadeEventArgs.cs
+++ b/Exiled.Events/EventArgs/ExplodingGrenadeEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs
     using System.Collections.Generic;
     using System.Linq;
 
+    using Exiled.API.Enums;
     using Exiled.API.Features;
 
     using UnityEngine;
@@ -37,7 +38,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the player who thrown the grenade.
+        /// Gets the player who threw the grenade.
         /// </summary>
         public Player Thrower { get; }
 

--- a/Exiled.Events/EventArgs/FailingEscapePocketDimensionEventArgs.cs
+++ b/Exiled.Events/EventArgs/FailingEscapePocketDimensionEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player dies from walking through the incorrect exit in the pocket dimension.
+    /// Contains all informations before a player dies from walking through an incorrect exit in the pocket dimension.
     /// </summary>
     public class FailingEscapePocketDimensionEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/FinishingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/FinishingRecallEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player is infected.
+    /// Contains all informations before SCP-049 finishes recalling a player.
     /// </summary>
     public class FinishingRecallEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/InteractingTeslaEventArgs.cs
+++ b/Exiled.Events/EventArgs/InteractingTeslaEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player triggers a tesla through SCP-079.
+    /// Contains all informations before SCP-079 triggers a tesla gate.
     /// </summary>
     public class InteractingTeslaEventArgs : EventArgs
     {
@@ -35,7 +35,7 @@ namespace Exiled.Events.EventArgs
         public Player Player { get; }
 
         /// <summary>
-        /// Gets the tesla game object, that SCP-079 is triggering.
+        /// Gets the <see cref="TeslaGate"/> that SCP-079 is triggering.
         /// </summary>
         public TeslaGate Tesla { get; }
 

--- a/Exiled.Events/EventArgs/IntercomSpeakingEventArgs.cs
+++ b/Exiled.Events/EventArgs/IntercomSpeakingEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player speaks to the itercom.
+    /// Contains all informations before a player speaks to the intercom.
     /// </summary>
     public class IntercomSpeakingEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/JoinedEventArgs.cs
+++ b/Exiled.Events/EventArgs/JoinedEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all player's informations, after he joins the server.
+    /// Contains all informations after a player joins the server.
     /// </summary>
     public class JoinedEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all iformations after kicking a player from the server.
+    /// Contains all informations after kicking a player from the server.
     /// </summary>
     public class KickedEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all iformations after banning a player from the server.
+    /// Contains all iformations after kicking a player from the server.
     /// </summary>
     public class KickedEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/KickingEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickingEventArgs.cs
@@ -14,7 +14,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.Events;
 
     /// <summary>
-    /// Contains all informations before kicking a player.
+    /// Contains all informations before kicking a player from the server.
     /// </summary>
     public class KickingEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/LocalReportingEventArgs.cs
+++ b/Exiled.Events/EventArgs/LocalReportingEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains information about the report to local administrators.
+    /// Contains informations before a report is sent to local administrators.
     /// </summary>
     public class LocalReportingEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/PickingUpScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/PickingUpScp330EventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player picks up an item.
+    /// Contains all informations before a player interacts with SCP-330.
     /// </summary>
     public class PickingUpScp330EventArgs : EventArgs
     {
@@ -33,7 +33,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the player who picking up the scp330.
+        /// Gets the player who picking up SCP-330.
         /// </summary>
         public Player Player { get; }
 

--- a/Exiled.Events/EventArgs/PickingUpScp330EventArgs.cs
+++ b/Exiled.Events/EventArgs/PickingUpScp330EventArgs.cs
@@ -33,7 +33,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets the player who picking up SCP-330.
+        /// Gets the player who's interacting with SCP-330.
         /// </summary>
         public Player Player { get; }
 

--- a/Exiled.Events/EventArgs/RemovingHandcuffsEventArgs.cs
+++ b/Exiled.Events/EventArgs/RemovingHandcuffsEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RemovingHandcuffsEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations freeing a handcuffed player.
+    /// Contains all informations before freeing a handcuffed player.
     /// </summary>
     public class RemovingHandcuffsEventArgs : HandcuffingEventArgs
     {

--- a/Exiled.Events/EventArgs/RespawningTeamEventArgs.cs
+++ b/Exiled.Events/EventArgs/RespawningTeamEventArgs.cs
@@ -17,7 +17,7 @@ namespace Exiled.Events.EventArgs
     using UnityEngine;
 
     /// <summary>
-    /// Contains all informations before spawning a wave of <see cref="Team.CHI"/> or <see cref="Team.MTF"/>..
+    /// Contains all informations before spawning a wave of <see cref="SpawnableTeamType.NineTailedFox"/> or <see cref="SpawnableTeamType.ChaosInsurgency"/>.
     /// </summary>
     public class RespawningTeamEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/SendingRemoteAdminCommandEventArgs.cs
+++ b/Exiled.Events/EventArgs/SendingRemoteAdminCommandEventArgs.cs
@@ -14,7 +14,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before the SCP-914 machine upgrades items inside it.
+    /// Contains all informations before sending a remote admin message.
     /// </summary>
     public class SendingRemoteAdminCommandEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningItemEventArgs.cs
@@ -8,9 +8,6 @@
 namespace Exiled.Events.EventArgs
 {
     using System;
-    using System.Collections.Generic;
-
-    using Exiled.API.Features;
 
     using UnityEngine;
 

--- a/Exiled.Events/EventArgs/SpawningRagdollEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningRagdollEventArgs.cs
@@ -91,7 +91,7 @@ namespace Exiled.Events.EventArgs
         public PlayerStats.HitInfo HitInformations { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the player can be revived by SCP-049 or not.
+        /// Gets or sets a value indicating whether or not the player can be revived by SCP-049.
         /// </summary>
         public bool IsRecallAllowed { get; set; }
 

--- a/Exiled.Events/EventArgs/StartingRecallEventArgs.cs
+++ b/Exiled.Events/EventArgs/StartingRecallEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player is infected.
+    /// Contains all informations before SCP-049 begins recalling a player.
     /// </summary>
     public class StartingRecallEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/StartingSpeakerEventArgs.cs
+++ b/Exiled.Events/EventArgs/StartingSpeakerEventArgs.cs
@@ -11,7 +11,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player triggers a speaker through SCP-079.
+    /// Contains all informations before SCP-079 uses a speaker.
     /// </summary>
     public class StartingSpeakerEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/StoppingMedicalItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/StoppingMedicalItemEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="StoppingMedicalItemEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
@@ -10,7 +10,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before the SCP-914 machine upgrades items inside it.
+    /// Contains all informations before a player cancels using a medical item.
     /// </summary>
     public class StoppingMedicalItemEventArgs : UsingMedicalItemEventArgs
     {

--- a/Exiled.Events/EventArgs/StoppingSpeakerEventArgs.cs
+++ b/Exiled.Events/EventArgs/StoppingSpeakerEventArgs.cs
@@ -11,7 +11,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before a player stopping a speaker through SCP-079.
+    /// Contains all informations before SCP-079 finishes using a speaker.
     /// </summary>
     public class StoppingSpeakerEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/TeleportingEventArgs.cs
+++ b/Exiled.Events/EventArgs/TeleportingEventArgs.cs
@@ -14,7 +14,7 @@ namespace Exiled.Events.EventArgs
     using UnityEngine;
 
     /// <summary>
-    /// Contains all informations before teleporting an SCP-106.
+    /// Contains all informations before SCP-106 teleports using a portal.
     /// </summary>
     public class TeleportingEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/UnlockingGeneratorEventArgs.cs
+++ b/Exiled.Events/EventArgs/UnlockingGeneratorEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations before the SCP-914 machine upgrades items inside it.
+    /// Contains all informations before a generator is unlocked.
     /// </summary>
     public class UnlockingGeneratorEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/UpgradingItemsEventArgs.cs
+++ b/Exiled.Events/EventArgs/UpgradingItemsEventArgs.cs
@@ -15,7 +15,7 @@ namespace Exiled.Events.EventArgs
     using global::Scp914;
 
     /// <summary>
-    /// Contains all informations before the SCP-914 machine upgrades items inside it.
+    /// Contains all informations before SCP-914 upgrades players and items.
     /// </summary>
     public class UpgradingItemsEventArgs : EventArgs
     {

--- a/Exiled.Events/EventArgs/UsedMedicalItemEventArgs.cs
+++ b/Exiled.Events/EventArgs/UsedMedicalItemEventArgs.cs
@@ -12,7 +12,7 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations after a player uses a medical item on himself.
+    /// Contains all informations after a player uses a medical item.
     /// </summary>
     public class UsedMedicalItemEventArgs : EventArgs
     {

--- a/Exiled.Events/Handlers/Map.cs
+++ b/Exiled.Events/Handlers/Map.cs
@@ -43,7 +43,7 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<AnnouncingNtfEntranceEventArgs> AnnouncingNtfEntrance;
 
         /// <summary>
-        /// Invoked after a generator has been activated.
+        /// Invoked after a <see cref="Generator079"/> has been activated.
         /// </summary>
         public static event CustomEventHandler<GeneratorActivatedEventArgs> GeneratorActivated;
 
@@ -103,7 +103,7 @@ namespace Exiled.Events.Handlers
         public static void OnAnnouncingNtfEntrance(AnnouncingNtfEntranceEventArgs ev) => AnnouncingNtfEntrance.InvokeSafely(ev);
 
         /// <summary>
-        /// Called after a generator has been activated.
+        /// Called after a <see cref="Generator079"/> has been activated.
         /// </summary>
         /// <param name="ev">The <see cref="GeneratorActivatedEventArgs"/> instance.</param>
         public static void OnGeneratorActivated(GeneratorActivatedEventArgs ev) => GeneratorActivated.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -266,12 +266,12 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<DeactivatingWorkstationEventArgs> DeactivatingWorkstation;
 
         /// <summary>
-        /// Invoked before a user's mute status is changed.
+        /// Invoked before an user's mute status is changed.
         /// </summary>
         public static event CustomEventHandler<ChangingMuteStatusEventArgs> ChangingMuteStatus;
 
         /// <summary>
-        /// Invoked before a user's intercom mute status is changed.
+        /// Invoked before an user's intercom mute status is changed.
         /// </summary>
         public static event CustomEventHandler<ChangingIntercomMuteStatusEventArgs> ChangingIntercomMuteStatus;
 
@@ -570,13 +570,13 @@ namespace Exiled.Events.Handlers
         public static void OnDeactivatingWorkstation(DeactivatingWorkstationEventArgs ev) => DeactivatingWorkstation.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before a user's mute status is changed.
+        /// Called before an user's mute status is changed.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingMuteStatusEventArgs"/> instance.</param>
         public static void OnChangingMuteStatus(ChangingMuteStatusEventArgs ev) => ChangingMuteStatus.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before a user's intercom mute status is changed.
+        /// Called before an user's intercom mute status is changed.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingIntercomMuteStatusEventArgs"/> instance.</param>
         public static void OnChangingIntercomMuteStatus(ChangingIntercomMuteStatusEventArgs ev) => ChangingIntercomMuteStatus.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -7,6 +7,8 @@
 
 namespace Exiled.Events.Handlers
 {
+    using System;
+
     using Exiled.Events.EventArgs;
     using Exiled.Events.Extensions;
 
@@ -23,27 +25,27 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<PreAuthenticatingEventArgs> PreAuthenticating;
 
         /// <summary>
-        /// Invoked before kicking a player.
+        /// Invoked before kicking a player from the server.
         /// </summary>
         public static event CustomEventHandler<KickingEventArgs> Kicking;
 
         /// <summary>
-        /// Invoked after a player has been kicked.
+        /// Invoked after a player has been kicked from the server.
         /// </summary>
         public static event CustomEventHandler<KickedEventArgs> Kicked;
 
         /// <summary>
-        /// Invoked before banning a player.
+        /// Invoked before banning a player from the server.
         /// </summary>
         public static event CustomEventHandler<BanningEventArgs> Banning;
 
         /// <summary>
-        /// Invoked after a player has been banned.
+        /// Invoked after a player has been banned from the server.
         /// </summary>
         public static event CustomEventHandler<BannedEventArgs> Banned;
 
         /// <summary>
-        /// Invoked after a player used a medical item.
+        /// Invoked after a player uses a medical item.
         /// </summary>
         public static event CustomEventHandler<UsedMedicalItemEventArgs> MedicalItemUsed;
 
@@ -118,13 +120,14 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ItemDroppedEventArgs> ItemDropped;
 
         /// <summary>
-        /// Invoked before picking up an item
+        /// Invoked before picking up an item.
         /// </summary>
         public static event CustomEventHandler<PickingUpItemEventArgs> PickingUpItem;
 
         /// <summary>
-        /// Invoked before picking up an scp330
+        /// Invoked before a player interacts with SCP-330.
         /// </summary>
+        [Obsolete("SCP-330 has been removed.", true)]
         public static event CustomEventHandler<PickingUpScp330EventArgs> PickingUpScp330;
 
         /// <summary>
@@ -133,47 +136,47 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<HandcuffingEventArgs> Handcuffing;
 
         /// <summary>
-        /// Invoked before removing handcuffs to a player.
+        /// Invoked before freeing a handcuffed player.
         /// </summary>
         public static event CustomEventHandler<RemovingHandcuffsEventArgs> RemovingHandcuffs;
 
         /// <summary>
-        /// Invoked before escaping from the facility.
+        /// Invoked before a player escapes.
         /// </summary>
         public static event CustomEventHandler<EscapingEventArgs> Escaping;
 
         /// <summary>
-        /// Invoked before speaking to the intercom.
+        /// Invoked before a player begins speaking to the intercom.
         /// </summary>
         public static event CustomEventHandler<IntercomSpeakingEventArgs> IntercomSpeaking;
 
         /// <summary>
-        /// Invoked after a player's shot.
+        /// Invoked after a player shoots a weapon.
         /// </summary>
         public static event CustomEventHandler<ShotEventArgs> Shot;
 
         /// <summary>
-        /// Invoked before shooting.
+        /// Invoked before a player shoots a weapon.
         /// </summary>
         public static event CustomEventHandler<ShootingEventArgs> Shooting;
 
         /// <summary>
-        /// Invoked before entering the pocket dimension.
+        /// Invoked before a player enters the pocket dimension.
         /// </summary>
         public static event CustomEventHandler<EnteringPocketDimensionEventArgs> EnteringPocketDimension;
 
         /// <summary>
-        /// Invoked before escaping the pocket dimension.
+        /// Invoked before a player escapes the pocket dimension.
         /// </summary>
         public static event CustomEventHandler<EscapingPocketDimensionEventArgs> EscapingPocketDimension;
 
         /// <summary>
-        /// Invoked before escaping the pocket dimension.
+        /// Invoked before a player fails to escape the pocket dimension.
         /// </summary>
         public static event CustomEventHandler<FailingEscapePocketDimensionEventArgs> FailingEscapePocketDimension;
 
         /// <summary>
-        /// Invoked before reloading a weapon.
+        /// Invoked before a player reloads a weapon.
         /// </summary>
         public static event CustomEventHandler<ReloadingWeaponEventArgs> ReloadingWeapon;
 
@@ -183,7 +186,7 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<SpawningEventArgs> Spawning;
 
         /// <summary>
-        /// Invoked before entering the femur breaker
+        /// Invoked before a player enters the femur breaker.
         /// </summary>
         public static event CustomEventHandler<EnteringFemurBreakerEventArgs> EnteringFemurBreaker;
 
@@ -193,7 +196,7 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<SyncingDataEventArgs> SyncingData;
 
         /// <summary>
-        /// Invoked before changing a player changes the item in his hand.
+        /// Invoked before a player's held item changes.
         /// </summary>
         public static event CustomEventHandler<ChangingItemEventArgs> ChangingItem;
 
@@ -203,287 +206,287 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ChangingGroupEventArgs> ChangingGroup;
 
         /// <summary>
-        /// Invoked before interacting with a door.
+        /// Invoked before a player interacts with a door.
         /// </summary>
         public static event CustomEventHandler<InteractingDoorEventArgs> InteractingDoor;
 
         /// <summary>
-        /// Invoked before interacting with an elevator.
+        /// Invoked before a player interacts with an elevator.
         /// </summary>
         public static event CustomEventHandler<InteractingElevatorEventArgs> InteractingElevator;
 
         /// <summary>
-        /// Invoked before interacting with a locker.
+        /// Invoked before a player interacts with a locker.
         /// </summary>
         public static event CustomEventHandler<InteractingLockerEventArgs> InteractingLocker;
 
         /// <summary>
-        /// Invoked before triggering a tesla.
+        /// Invoked before a player triggers a tesla gate.
         /// </summary>
         public static event CustomEventHandler<TriggeringTeslaEventArgs> TriggeringTesla;
 
         /// <summary>
-        /// Invoked before unlocking a generator.
+        /// Invoked before a player unlocks a generator.
         /// </summary>
         public static event CustomEventHandler<UnlockingGeneratorEventArgs> UnlockingGenerator;
 
         /// <summary>
-        /// Invoked before opening a generator.
+        /// Invoked before a player opens a generator.
         /// </summary>
         public static event CustomEventHandler<OpeningGeneratorEventArgs> OpeningGenerator;
 
         /// <summary>
-        /// Invoked befroe closing a generator.
+        /// Invoked before a player closes a generator.
         /// </summary>
         public static event CustomEventHandler<ClosingGeneratorEventArgs> ClosingGenerator;
 
         /// <summary>
-        /// Invoked before inserting a generator.
+        /// Invoked before a player inserts a workstation tablet into a generator.
         /// </summary>
         public static event CustomEventHandler<InsertingGeneratorTabletEventArgs> InsertingGeneratorTablet;
 
         /// <summary>
-        /// Invoked before ejecting a generator.
+        /// Invoked before a player ejects the workstation tablet out of a generator.
         /// </summary>
         public static event CustomEventHandler<EjectingGeneratorTabletEventArgs> EjectingGeneratorTablet;
 
         /// <summary>
-        /// Invoked before receiving an effect.
+        /// Invoked before a player receives a status effect.
         /// </summary>
         public static event CustomEventHandler<ReceivingEffectEventArgs> ReceivingEffect;
 
         /// <summary>
-        /// Invoked before activating workstation.
+        /// Invoked before a workstation is activated.
         /// </summary>
         public static event CustomEventHandler<ActivatingWorkstationEventArgs> ActivatingWorkstation;
 
         /// <summary>
-        /// Invoked before deactivating workstation.
+        /// Invoked before a workstation is deactivated.
         /// </summary>
         public static event CustomEventHandler<DeactivatingWorkstationEventArgs> DeactivatingWorkstation;
 
         /// <summary>
-        /// Invoked before changing user mute status.
+        /// Invoked before a user's mute status is changed.
         /// </summary>
         public static event CustomEventHandler<ChangingMuteStatusEventArgs> ChangingMuteStatus;
 
         /// <summary>
-        /// Invoked before changing user intercom mute status.
+        /// Invoked before a user's intercom mute status is changed.
         /// </summary>
         public static event CustomEventHandler<ChangingIntercomMuteStatusEventArgs> ChangingIntercomMuteStatus;
 
         /// <summary>
-        /// Invoked before pre-authenticating a player.
+        /// Called before pre-authenticating a player.
         /// </summary>
         /// <param name="ev">The <see cref="PreAuthenticatingEventArgs"/> instance.</param>
         public static void OnPreAuthenticating(PreAuthenticatingEventArgs ev) => PreAuthenticating.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before kicking a player.
+        /// Called before kicking a player from the server.
         /// </summary>
         /// <param name="ev">The <see cref="KickingEventArgs"/> instance.</param>
         public static void OnKicking(KickingEventArgs ev) => Kicking.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player has been kicked.
+        /// Called after a player has been kicked from the server.
         /// </summary>
         /// <param name="ev">The <see cref="KickedEventArgs"/> instance.</param>
         public static void OnKicked(KickedEventArgs ev) => Kicked.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before banning a player.
+        /// Called before banning a player from the server.
         /// </summary>
         /// <param name="ev">The <see cref="BanningEventArgs"/> instance.</param>
         public static void OnBanning(BanningEventArgs ev) => Banning.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player has been banned.
+        /// Called after a player has been banned from the server.
         /// </summary>
         /// <param name="ev">The <see cref="BannedEventArgs"/> instance.</param>
         public static void OnBanned(BannedEventArgs ev) => Banned.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player used a medical item.
+        /// Called after a player used a medical item.
         /// </summary>
         /// <param name="ev">The <see cref="MedicalItemUsed"/> instance.</param>
         public static void OnMedicalItemUsed(UsedMedicalItemEventArgs ev) => MedicalItemUsed.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player has stopped the use of a medical item.
+        /// Called after a player has stopped the use of a medical item.
         /// </summary>
         /// <param name="ev">The <see cref="StoppingMedicalItemEventArgs"/> instance.</param>
         public static void OnStoppingMedicalItem(StoppingMedicalItemEventArgs ev) => StoppingMedicalItem.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player interacted with something.
+        /// Called after a player interacted with something.
         /// </summary>
         /// <param name="ev">The <see cref="InteractedEventArgs"/> instance.</param>
         public static void OnInteracted(InteractedEventArgs ev) => Interacted.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before spawning a player's ragdoll.
+        /// Called before spawning a player's ragdoll.
         /// </summary>
         /// <param name="ev">The <see cref="SpawningRagdollEventArgs"/> instance.</param>
         public static void OnSpawningRagdoll(SpawningRagdollEventArgs ev) => SpawningRagdoll.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before activating the warhead panel.
+        /// Called before activating the warhead panel.
         /// </summary>
         /// <param name="ev">The <see cref="ActivatingWarheadPanelEventArgs"/> instance.</param>
         public static void OnActivatingWarheadPanel(ActivatingWarheadPanelEventArgs ev) => ActivatingWarheadPanel.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before using a medical item.
+        /// Called before using a medical item.
         /// </summary>
         /// <param name="ev">The <see cref="UsingMedicalItemEventArgs"/> instance.</param>
         public static void OnUsingMedicalItem(UsingMedicalItemEventArgs ev) => UsingMedicalItem.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player has joined the server.
+        /// Called after a player has joined the server.
         /// </summary>
         /// <param name="ev">The <see cref="JoinedEventArgs"/> instance.</param>
         public static void OnJoined(JoinedEventArgs ev) => Joined.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player has left the server.
+        /// Called after a player has left the server.
         /// </summary>
         /// <param name="ev">The <see cref="LeftEventArgs"/> instance.</param>
         public static void OnLeft(LeftEventArgs ev) => Left.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before hurting a player.
+        /// Called before hurting a player.
         /// </summary>
         /// <param name="ev">The <see cref="HurtingEventArgs"/> instance.</param>
         public static void OnHurting(HurtingEventArgs ev) => Hurting.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before a player dies.
+        /// Called before a player dies.
         /// </summary>
         /// <param name="ev"><see cref="DyingEventArgs"/> instance.</param>
         public static void OnDying(DyingEventArgs ev) => Dying.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player died.
+        /// Called after a player died.
         /// </summary>
         /// <param name="ev">The <see cref="DiedEventArgs"/> instance.</param>
         public static void OnDied(DiedEventArgs ev) => Died.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before changing a player's role.
+        /// Called before changing a player's role.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingRoleEventArgs"/> instance.</param>
         public static void OnChangingRole(ChangingRoleEventArgs ev) => ChangingRole.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before throwing a grenade.
+        /// Called before throwing a grenade.
         /// </summary>
         /// <param name="ev">The <see cref="ThrowingGrenadeEventArgs"/> instance.</param>
         public static void OnThrowingGrenade(ThrowingGrenadeEventArgs ev) => ThrowingGrenade.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before dropping an item.
+        /// Called before dropping an item.
         /// </summary>
         /// <param name="ev">The <see cref="DroppingItemEventArgs"/> instance.</param>
         public static void OnDroppingItem(DroppingItemEventArgs ev) => DroppingItem.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after an item has been dropped.
+        /// Called after a player drops an item.
         /// </summary>
         /// <param name="ev">The <see cref="ItemDroppedEventArgs"/> instance.</param>
         public static void OnItemDropped(ItemDroppedEventArgs ev) => ItemDropped.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before picking up an item.
+        /// Called before a user picks up an item.
         /// </summary>
         /// <param name="ev">The <see cref="PickingUpItemEventArgs"/> instance.</param>
         public static void OnPickingUpItem(PickingUpItemEventArgs ev) => PickingUpItem.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before picking up an item.
+        /// Called before a player picks up an item.
         /// </summary>
         /// <param name="ev">The <see cref="PickingUpScp330EventArgs"/> instance.</param>
         public static void OnPickingUpScp330(PickingUpScp330EventArgs ev) => PickingUpScp330.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before handcuffing a player.
+        /// Called before handcuffing a player.
         /// </summary>
         /// <param name="ev">The <see cref="HandcuffingEventArgs"/> instance.</param>
         public static void OnHandcuffing(HandcuffingEventArgs ev) => Handcuffing.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before removing handcuffs to a player.
+        /// Called before freeing a handcuffed player.
         /// </summary>
         /// <param name="ev">The <see cref="RemovingHandcuffsEventArgs"/> instance.</param>
         public static void OnRemovingHandcuffs(RemovingHandcuffsEventArgs ev) => RemovingHandcuffs.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before escaping from the facility.
+        /// Called before a player escapes.
         /// </summary>
         /// <param name="ev">The <see cref="EscapingEventArgs"/> instance.</param>
         public static void OnEscaping(EscapingEventArgs ev) => Escaping.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before speaking to the intercom.
+        /// Called before a player begins speaking to the intercom.
         /// </summary>
         /// <param name="ev">The <see cref="IntercomSpeakingEventArgs"/> instance.</param>
         public static void OnIntercomSpeaking(IntercomSpeakingEventArgs ev) => IntercomSpeaking.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked after a player's shot.
+        /// Called after a player shoots a weapon.
         /// </summary>
         /// <param name="ev">The <see cref="ShotEventArgs"/> instance.</param>
         public static void OnShot(ShotEventArgs ev) => Shot.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before shooting.
+        /// Called before a player shoots a weapon.
         /// </summary>
         /// <param name="ev">The <see cref="ShootingEventArgs"/> instance.</param>
         public static void OnShooting(ShootingEventArgs ev) => Shooting.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before entering the pocket dimension.
+        /// Called before a player enters the pocket dimension.
         /// </summary>
         /// <param name="ev">The <see cref="EnteringPocketDimensionEventArgs"/> instance.</param>
         public static void OnEnteringPocketDimension(EnteringPocketDimensionEventArgs ev) => EnteringPocketDimension.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before escaping the pocket dimension.
+        /// Called before a player escapes the pocket dimension.
         /// </summary>
         /// <param name="ev">The <see cref="EscapingPocketDimensionEventArgs"/> instance.</param>
         public static void OnEscapingPocketDimension(EscapingPocketDimensionEventArgs ev) => EscapingPocketDimension.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before choosing the incorrect pocket dimension exit.
+        /// Called before a player fails to escape the pocket dimension.
         /// </summary>
         /// <param name="ev">The <see cref="FailingEscapePocketDimensionEventArgs"/> instance.</param>
         public static void OnFailingEscapePocketDimension(FailingEscapePocketDimensionEventArgs ev) => FailingEscapePocketDimension.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before reloading a weapon.
+        /// Called before a player reloads a weapon.
         /// </summary>
         /// <param name="ev">The <see cref="ReloadingWeaponEventArgs"/> instance.</param>
         public static void OnReloadingWeapon(ReloadingWeaponEventArgs ev) => ReloadingWeapon.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before spawning a player.
+        /// Called before spawning a player.
         /// </summary>
         /// <param name="ev">The <see cref="SpawningEventArgs"/> instance.</param>
         public static void OnSpawning(SpawningEventArgs ev) => Spawning.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before entering the femur breaker.
+        /// Called before a player enters the femur breaker.
         /// </summary>
         /// <param name="ev">The <see cref="EnteringFemurBreakerEventArgs"/> instance.</param>
         public static void OnEnteringFemurBreaker(EnteringFemurBreakerEventArgs ev) => EnteringFemurBreaker.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before syncing player's data.
+        /// Called before syncing player's data.
         /// </summary>
         /// <param name="ev">The <see cref="SyncingDataEventArgs"/> instance.</param>
         public static void OnSyncingData(SyncingDataEventArgs ev) => SyncingData.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before changing a player changes the item in his hand.
+        /// Called before a player's held item changes.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingItemEventArgs"/> instance.</param>
         public static void OnChangingItem(ChangingItemEventArgs ev) => ChangingItem.InvokeSafely(ev);
@@ -495,85 +498,85 @@ namespace Exiled.Events.Handlers
         public static void OnChangingGroup(ChangingGroupEventArgs ev) => ChangingGroup.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before interacting with a door.
+        /// Called before a player interacts with a door.
         /// </summary>
         /// <param name="ev">The <see cref="PlacingDecalEventArgs"/> instance.</param>
         public static void OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before interacting with an elevator.
+        /// Called before a player interacts with an elevator.
         /// </summary>
         /// <param name="ev">The <see cref="PlacingDecalEventArgs"/> instance.</param>
         public static void OnInteractingElevator(InteractingElevatorEventArgs ev) => InteractingElevator.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before interacting with a locker.
+        /// Called before a player interacts with a locker.
         /// </summary>
         /// <param name="ev">The <see cref="PlacingDecalEventArgs"/> instance.</param>
         public static void OnInteractingLocker(InteractingLockerEventArgs ev) => InteractingLocker.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before triggering a tesla.
+        /// Called before a player triggers a tesla.
         /// </summary>
         /// <param name="ev">The <see cref="TriggeringTeslaEventArgs"/> instance.</param>
         public static void OnTriggeringTesla(TriggeringTeslaEventArgs ev) => TriggeringTesla.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before unlocking a generator.
+        /// Called before a player unlocks a generator.
         /// </summary>
         /// <param name="ev">The <see cref="UnlockingGeneratorEventArgs"/> instance.</param>
         public static void OnUnlockingGenerator(UnlockingGeneratorEventArgs ev) => UnlockingGenerator.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before opening a generator.
+        /// Called before a player opens a generator.
         /// </summary>
         /// <param name="ev">The <see cref="OpeningGeneratorEventArgs"/> instance.</param>
         public static void OnOpeningGenerator(OpeningGeneratorEventArgs ev) => OpeningGenerator.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before closing a generator.
+        /// Called before a player closes a generator.
         /// </summary>
         /// <param name="ev">The <see cref="ClosingGeneratorEventArgs"/> instance.</param>
         public static void OnClosingGenerator(ClosingGeneratorEventArgs ev) => ClosingGenerator.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before inserting a generator.
+        /// Called before a player inserts a workstation tablet into a generator.
         /// </summary>
         /// <param name="ev">The <see cref="InsertingGeneratorTabletEventArgs"/> instance.</param>
         public static void OnInsertingGeneratorTablet(InsertingGeneratorTabletEventArgs ev) => InsertingGeneratorTablet.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before ejecting a generator.
+        /// Called before a player ejects the workstation tablet out of a generator.
         /// </summary>
         /// <param name="ev">The <see cref="EjectingGeneratorTabletEventArgs"/> instance.</param>
         public static void OnEjectingGeneratorTablet(EjectingGeneratorTabletEventArgs ev) => EjectingGeneratorTablet.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before receiving an effect.
+        /// Called before a player receives a status effect.
         /// </summary>
         /// <param name="ev">The <see cref="ReceivingEffectEventArgs"/> instance.</param>
         public static void OnReceivingEffect(ReceivingEffectEventArgs ev) => ReceivingEffect.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before activating workstation.
+        /// Called before a workstation is activated.
         /// </summary>
         /// <param name="ev">The <see cref="ActivatingWorkstationEventArgs"/> instance.</param>
         public static void OnActivatingWorkstation(ActivatingWorkstationEventArgs ev) => ActivatingWorkstation.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before deactivating workstation.
+        /// Called before a workstation is deactivated.
         /// </summary>
         /// <param name="ev">The <see cref="DeactivatingWorkstationEventArgs"/> instance.</param>
         public static void OnDeactivatingWorkstation(DeactivatingWorkstationEventArgs ev) => DeactivatingWorkstation.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before changing user mute status.
+        /// Called before a user's mute status is changed.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingMuteStatusEventArgs"/> instance.</param>
         public static void OnChangingMuteStatus(ChangingMuteStatusEventArgs ev) => ChangingMuteStatus.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before changing user intercom mute status.
+        /// Called before a user's intercom mute status is changed.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingIntercomMuteStatusEventArgs"/> instance.</param>
         public static void OnChangingIntercomMuteStatus(ChangingIntercomMuteStatusEventArgs ev) => ChangingIntercomMuteStatus.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Scp049.cs
+++ b/Exiled.Events/Handlers/Scp049.cs
@@ -13,28 +13,28 @@ namespace Exiled.Events.Handlers
     using static Exiled.Events.Events;
 
     /// <summary>
-    /// Scp049 related events.
+    /// SCP-049 related events.
     /// </summary>
     public static class Scp049
     {
         /// <summary>
-        /// Invoked before a player is infected.
+        /// Invoked before SCP-049 finishes recalling a player.
         /// </summary>
         public static event CustomEventHandler<FinishingRecallEventArgs> FinishingRecall;
 
         /// <summary>
-        /// Invoked before Scp049 starts to infect a player.
+        /// Invoked before SCP-049 begins recalling a player.
         /// </summary>
         public static event CustomEventHandler<StartingRecallEventArgs> StartingRecall;
 
         /// <summary>
-        /// Invoked before a player is recalled.
+        /// Called before SCP-049 finishes recalling a player.
         /// </summary>
         /// <param name="ev">The <see cref="FinishingRecallEventArgs"/> instance.</param>
         public static void OnFinishingRecall(FinishingRecallEventArgs ev) => FinishingRecall.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before Scp049 starts to recall a player.
+        /// Called before Scp049 starts to recall a player.
         /// </summary>
         /// <param name="ev">The <see cref="StartingRecallEventArgs"/> instance.</param>
         public static void OnStartingRecall(StartingRecallEventArgs ev) => StartingRecall.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Scp079.cs
+++ b/Exiled.Events/Handlers/Scp079.cs
@@ -38,12 +38,12 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<InteractingDoorEventArgs> InteractingDoor;
 
         /// <summary>
-        /// Invoked before triggering a speaker with SCP-079.
+        /// Invoked before SCP-079 uses a speaker.
         /// </summary>
         public static event CustomEventHandler<StartingSpeakerEventArgs> StartingSpeaker;
 
         /// <summary>
-        /// Invoked before stopping a speaker with SCP-079.
+        /// Invoked before SCP-079 finishes using a speaker.
         /// </summary>
         public static event CustomEventHandler<StoppingSpeakerEventArgs> StoppingSpeaker;
 
@@ -53,43 +53,43 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<RecontainedEventArgs> Recontained;
 
         /// <summary>
-        /// Invoked before gaining experience with SCP-079.
+        /// Called before gaining experience with SCP-079.
         /// </summary>
         /// <param name="ev">The <see cref="GainingExperienceEventArgs"/> instance.</param>
         public static void OnGainingExperience(GainingExperienceEventArgs ev) => GainingExperience.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before gaining levels with SCP-079.
+        /// Called before gaining levels with SCP-079.
         /// </summary>
         /// <param name="ev">The <see cref="GainingLevelEventArgs"/> instance.</param>
         public static void OnGainingLevel(GainingLevelEventArgs ev) => GainingLevel.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before triggering a tesla with SCP-079.
+        /// Called before triggering a tesla with SCP-079.
         /// </summary>
         /// <param name="ev">The <see cref="InteractingTeslaEventArgs"/> instance.</param>
         public static void OnInteractingTesla(InteractingTeslaEventArgs ev) => InteractingTesla.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before interacting with a door with SCP-079.
+        /// Called before interacting with a door with SCP-079.
         /// </summary>
         /// <param name="ev">The <see cref="InteractingDoorEventArgs"/> instance.</param>
         public static void OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before interacting with a speaker with SCP-079.
+        /// Called before interacting with a speaker with SCP-079.
         /// </summary>
         /// <param name="ev">The <see cref="StartingSpeakerEventArgs"/> instance.</param>
         public static void OnStartingSpeaker(StartingSpeakerEventArgs ev) => StartingSpeaker.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before stopping with a speaker with SCP-079.
+        /// Called before SCP-079 finishes using a speaker.
         /// </summary>
         /// <param name="ev">The <see cref="StoppingEventArgs"/> instance.</param>
         public static void OnStoppingSpeaker(StoppingSpeakerEventArgs ev) => StoppingSpeaker.InvokeSafely(ev);
 
         /// <summary>
-        /// Called after 079 recontainment.
+        /// Called after SCP-079 is recontained.
         /// </summary>
         /// <param name="ev">The <see cref="RecontainedEventArgs"/> instance.</param>
         public static void OnRecontained(RecontainedEventArgs ev) => Recontained.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Scp096.cs
+++ b/Exiled.Events/Handlers/Scp096.cs
@@ -18,12 +18,12 @@ namespace Exiled.Events.Handlers
     public static class Scp096
     {
         /// <summary>
-        /// Invoked before enraging with SCP-096.
+        /// Invoked before SCP-096 is enraged.
         /// </summary>
         public static event CustomEventHandler<EnragingEventArgs> Enraging;
 
         /// <summary>
-        /// Invoked before calming down with SCP-096.
+        /// Invoked before SCP-096 calms down.
         /// </summary>
         public static event CustomEventHandler<CalmingDownEventArgs> CalmingDown;
 
@@ -33,30 +33,30 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<AddingTargetEventArgs> AddingTarget;
 
         /// <summary>
-        /// Invoked before Scp096 starts prying open a gate.
+        /// Invoked before SCP-096 begins prying open a gate.
         /// </summary>
         public static event CustomEventHandler<StartPryingGateEventArgs> StartPryingGate;
 
         /// <summary>
-        /// Invoked before enraging with SCP-096.
+        /// Called before SCP-096 is enraged.
         /// </summary>
         /// <param name="ev">The <see cref="EnragingEventArgs"/> instance.</param>
         public static void OnEnraging(EnragingEventArgs ev) => Enraging.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before calming down with SCP-096.
+        /// Called before SCP-096 calms down.
         /// </summary>
         /// <param name="ev">The <see cref="CalmingDownEventArgs"/> instance.</param>
         public static void OnCalmingDown(CalmingDownEventArgs ev) => CalmingDown.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before adding a target to SCP-096.
+        /// Called before adding a target to SCP-096.
         /// </summary>
         /// <param name="ev">The <see cref="AddingTargetEventArgs"/> instance.</param>
         public static void OnAddingTarget(AddingTargetEventArgs ev) => AddingTarget.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before Scp096 starts prying open a gate.
+        /// Called before SCP-096 begins prying open a gate.
         /// </summary>
         /// <param name="ev">The <see cref="StartPryingGateEventArgs"/> instance.</param>
         public static void OnStartPryingGate(StartPryingGateEventArgs ev) => StartPryingGate.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Scp106.cs
+++ b/Exiled.Events/Handlers/Scp106.cs
@@ -18,12 +18,12 @@ namespace Exiled.Events.Handlers
     public static class Scp106
     {
         /// <summary>
-        /// Invoked before creating an SCP-106 portal.
+        /// Invoked before SCP-106 creates a portal.
         /// </summary>
         public static event CustomEventHandler<CreatingPortalEventArgs> CreatingPortal;
 
         /// <summary>
-        /// Invoked before teleporting with SCP-106.
+        /// Invoked before SCP-106 teleports using a portal.
         /// </summary>
         public static event CustomEventHandler<TeleportingEventArgs> Teleporting;
 
@@ -33,19 +33,19 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ContainingEventArgs> Containing;
 
         /// <summary>
-        /// Invoked before creating an SCP-106 portal.
+        /// Called before SCP-106 creates a portal.
         /// </summary>
         /// <param name="ev">The <see cref="CreatingPortalEventArgs"/> instance.</param>
         public static void OnCreatingPortal(CreatingPortalEventArgs ev) => CreatingPortal.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before teleporting with SCP-106.
+        /// Called before SCP-106 teleports using a portal.
         /// </summary>
         /// <param name="ev">The <see cref="TeleportingEventArgs"/> instance.</param>
         public static void OnTeleporting(TeleportingEventArgs ev) => Teleporting.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before containing SCP-106.
+        /// Called before containing SCP-106.
         /// </summary>
         /// <param name="ev">The <see cref="ContainingEventArgs"/> instance.</param>
         public static void OnContaining(ContainingEventArgs ev) => Containing.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Scp914.cs
+++ b/Exiled.Events/Handlers/Scp914.cs
@@ -18,7 +18,7 @@ namespace Exiled.Events.Handlers
     public static class Scp914
     {
         /// <summary>
-        /// Invoked before upgrading items in the SCP-914 machine.
+        /// Invoked before SCP-914 upgrades players and items.
         /// </summary>
         public static event CustomEventHandler<UpgradingItemsEventArgs> UpgradingItems;
 
@@ -33,19 +33,19 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ChangingKnobSettingEventArgs> ChangingKnobSetting;
 
         /// <summary>
-        /// Called before upgrading items in the SCP-914 machine.
+        /// Called before SCP-914 upgrades players and items.
         /// </summary>
         /// <param name="ev">The <see cref="UpgradingItemsEventArgs"/> instance.</param>
         public static void OnUpgradingItems(UpgradingItemsEventArgs ev) => UpgradingItems.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before activating the SCP-914 machine.
+        /// Called before activating the SCP-914 machine.
         /// </summary>
         /// <param name="ev">The <see cref="ActivatingEventArgs"/> instance.</param>
         public static void OnActivating(ActivatingEventArgs ev) => Activating.InvokeSafely(ev);
 
         /// <summary>
-        /// Invoked before changing the SCP-914 machine knob setting.
+        /// Called before changing the SCP-914 machine knob setting.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingKnobSettingEventArgs"/> instance.</param>
         public static void OnChangingKnobSetting(ChangingKnobSettingEventArgs ev) => ChangingKnobSetting.InvokeSafely(ev);

--- a/Exiled.Events/Handlers/Server.cs
+++ b/Exiled.Events/Handlers/Server.cs
@@ -32,7 +32,7 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler RoundStarted;
 
         /// <summary>
-        /// Invoked before ending a round
+        /// Invoked before ending a round.
         /// </summary>
         public static event CustomEventHandler<EndingRoundEventArgs> EndingRound;
 

--- a/Exiled.Events/Handlers/Warhead.cs
+++ b/Exiled.Events/Handlers/Warhead.cs
@@ -55,7 +55,7 @@ namespace Exiled.Events.Handlers
         public static void OnDetonated() => Detonated.InvokeSafely();
 
         /// <summary>
-        /// Invoked before changing the warhead lever status.
+        /// Called before changing the warhead lever status.
         /// </summary>
         /// <param name="ev">The <see cref="ChangingLeverStatusEventArgs"/> instance.</param>
         public static void OnChangingLeverStatus(ChangingLeverStatusEventArgs ev) => ChangingLeverStatus.InvokeSafely(ev);


### PR DESCRIPTION
* Essentially doing the devil's work
  - Fixing up multiple typos (including a typo that said SCP-096 creates portals, duplicated "mm" in an ammunition enum, etc)
  - All event handlers' summaries now say "Invoked ..." while all of their respective methods say "Called ..."
  - Adding consistency between event arguments and their respective handlers
  - Adding consistent usage of "SCPs", "SCP-###", etc.
  - Fixing miscellaneous English grammatical errors
* If you review these manually: Sorry in advance, I felt really dedicated tonight