### PR TITLE
Round::ForceEnd

### DIFF
--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -8,7 +8,6 @@
 namespace Exiled.API.Features
 {
     using System;
-    using System.Linq;
 
     using GameCore;
 
@@ -58,17 +57,21 @@ namespace Exiled.API.Features
         /// <summary>
         /// Forces the round to end, regardless of which factions are alive.
         /// </summary>
-        public static void ForceEnd()
+        /// <returns>A <see cref="bool"/> describing whether or not the round was successfully ended.</returns>
+        public static bool ForceEnd()
         {
-            if (RoundSummary.singleton._keepRoundOnOne && Player.List.Count() < 2)
+            if (RoundSummary.singleton._keepRoundOnOne && Player.Dictionary.Count < 2)
             {
-                return;
+                return false;
             }
 
             if (IsStarted && !IsLocked)
             {
                 RoundSummary.singleton.ForceEnd();
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -8,6 +8,7 @@
 namespace Exiled.API.Features
 {
     using System;
+    using System.Linq;
 
     using GameCore;
 
@@ -57,7 +58,13 @@ namespace Exiled.API.Features
         /// <summary>
         /// Forces the round to end, regardless of which factions are alive.
         /// </summary>
-        public static void ForceEnd() => RoundSummary.singleton.ForceEnd();
+        public static void ForceEnd()
+        {
+            if (IsStarted && Player.List.Count() > 1 && !IsLocked)
+            {
+                RoundSummary.singleton.ForceEnd();
+            }
+        }
 
         /// <summary>
         /// Start the round.

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -55,6 +55,11 @@ namespace Exiled.API.Features
         public static void Restart() => Server.Host.ReferenceHub.playerStats.Roundrestart();
 
         /// <summary>
+        /// Force ends the round.
+        /// </summary>
+        public static void ForceEnd() => RoundSummary.singleton.ForceEnd();
+
+        /// <summary>
         /// Start the round.
         /// </summary>
         public static void Start() => CharacterClassManager.ForceRoundStart();

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -55,7 +55,7 @@ namespace Exiled.API.Features
         public static void Restart() => Server.Host.ReferenceHub.playerStats.Roundrestart();
 
         /// <summary>
-        /// Force ends the round.
+        /// Forces the round to end, regardless of which factions are alive.
         /// </summary>
         public static void ForceEnd() => RoundSummary.singleton.ForceEnd();
 

--- a/Exiled.API/Features/Round.cs
+++ b/Exiled.API/Features/Round.cs
@@ -60,7 +60,12 @@ namespace Exiled.API.Features
         /// </summary>
         public static void ForceEnd()
         {
-            if (IsStarted && Player.List.Count() > 1 && !IsLocked)
+            if (RoundSummary.singleton._keepRoundOnOne && Player.List.Count() < 2)
+            {
+                return;
+            }
+
+            if (IsStarted && !IsLocked)
             {
                 RoundSummary.singleton.ForceEnd();
             }


### PR DESCRIPTION
`Round::ForceEnd()` - Quickhand for `RoundSummary.singleton::ForceEnd` (ends the round, shows the end summary and stuff)