### PR TITLE
Map Intercom APIs

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -160,7 +160,7 @@ namespace Exiled.API.Features
         public static bool IntercomInUse => IntercomState == Intercom.State.Transmitting || IntercomState == Intercom.State.TransmittingBypass || IntercomState == Intercom.State.AdminSpeaking;
 
         /// <summary>
-        /// Gets the <see cref="Player"/> that is using the intercom. Will be <see cref="null"/> if <see cref="IntercomInUse"/> is false.
+        /// Gets the <see cref="Player"/> that is using the intercom. Will be null if <see cref="IntercomInUse"/> is false.
         /// </summary>
         public static Player IntercomSpeaker => Player.Get(Intercom.host.speaker);
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -152,12 +152,12 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the intercom is currently being used.
         /// </summary>
-        public static bool IntercomInUse => Intercom.host.Network_state == Intercom.State.Transmitting || Intercom.host.Network_state == Intercom.State.TransmittingBypass || Intercom.host.Network_state == Intercom.State.AdminSpeaking;
+        public static bool IntercomInUse => IntercomState == Intercom.State.Transmitting || IntercomState == Intercom.State.TransmittingBypass || IntercomState == Intercom.State.AdminSpeaking;
 
         /// <summary>
         /// Gets the current state of the intercom.
         /// </summary>
-        public static Intercom.State IntercomState => Intercom.host.Network_state;
+        public static Intercom.State IntercomState => Intercom.host.IntercomState;
 
         /// <summary>
         /// Gets the <see cref="Player"/> that is using the intercom. Will be <see cref="null"/> if <see cref="IntercomInUse"/> is false.

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -150,6 +150,21 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Gets a value indicating whether or not the intercom is currently being used.
+        /// </summary>
+        public static bool IntercomInUse => Intercom.host.Network_state == Intercom.State.Transmitting || Intercom.host.Network_state == Intercom.State.TransmittingBypass || Intercom.host.Network_state == Intercom.State.AdminSpeaking;
+
+        /// <summary>
+        /// Gets the current state of the intercom.
+        /// </summary>
+        public static Intercom.State IntercomState => Intercom.host.Network_state;
+
+        /// <summary>
+        /// Gets the <see cref="Player"/> that is using the intercom. Will be <see cref="null"/> if <see cref="IntercomInUse"/> is false.
+        /// </summary>
+        public static Player IntercomSpeaker => Player.Get(Intercom.host.speaker);
+
+        /// <summary>
         /// Tries to find the room that a <see cref="GameObject"/> is inside, first using the <see cref="Transform"/>'s parents, then using a Raycast if no room was found.
         /// </summary>
         /// <param name="objectInRoom">The Game Object inside the room.</param>

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -150,14 +150,14 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Gets a value indicating whether or not the intercom is currently being used.
-        /// </summary>
-        public static bool IntercomInUse => IntercomState == Intercom.State.Transmitting || IntercomState == Intercom.State.TransmittingBypass || IntercomState == Intercom.State.AdminSpeaking;
-
-        /// <summary>
         /// Gets the current state of the intercom.
         /// </summary>
         public static Intercom.State IntercomState => Intercom.host.IntercomState;
+
+        /// <summary>
+        /// Gets a value indicating whether or not the intercom is currently being used.
+        /// </summary>
+        public static bool IntercomInUse => IntercomState == Intercom.State.Transmitting || IntercomState == Intercom.State.TransmittingBypass || IntercomState == Intercom.State.AdminSpeaking;
 
         /// <summary>
         /// Gets the <see cref="Player"/> that is using the intercom. Will be <see cref="null"/> if <see cref="IntercomInUse"/> is false.


### PR DESCRIPTION
Giving the intercom some love, since there's not much API for it atm.
* `Map::IntercomState` (Intercom.State) - State of the intercom
* `Map::IntercomInUse` (bool) - Whether or not IntercomState is equal to Transmitting, TransmittingBypass, or AdminSpeaking
* `Map::IntercomPlayer` (Player) - Reference to the player that is using the intercom