### PR TITLE
Adding return value to Player::EnableEffect

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1221,10 +1221,8 @@ namespace Exiled.API.Features
         /// <param name="effect">The name of the <see cref="PlayerEffect"/> to enable.</param>
         /// <param name="duration">The amount of time the effect will be active for.</param>
         /// <param name="addDurationIfActive">If the effect is already active, setting to true will add this duration onto the effect.</param>
-        public void EnableEffect(string effect, float duration = 0f, bool addDurationIfActive = false)
-        {
-            ReferenceHub.playerEffectsController.EnableByString(effect, duration, addDurationIfActive);
-        }
+        /// <returns>A bool indicating whether or not the effect was successfully enabled.</returns>
+        public bool EnableEffect(string effect, float duration = 0f, bool addDurationIfActive = false) => ReferenceHub.playerEffectsController.EnableByString(effect, duration, addDurationIfActive);
 
         /// <summary>
         /// Removes the player's hands.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -1221,7 +1221,7 @@ namespace Exiled.API.Features
         /// <param name="effect">The name of the <see cref="PlayerEffect"/> to enable.</param>
         /// <param name="duration">The amount of time the effect will be active for.</param>
         /// <param name="addDurationIfActive">If the effect is already active, setting to true will add this duration onto the effect.</param>
-        /// <returns>A bool indicating whether or not the effect was successfully enabled.</returns>
+        /// <returns>A bool indicating whether or not the effect was valid and successfully enabled.</returns>
         public bool EnableEffect(string effect, float duration = 0f, bool addDurationIfActive = false) => ReferenceHub.playerEffectsController.EnableByString(effect, duration, addDurationIfActive);
 
         /// <summary>


### PR DESCRIPTION
PlayerEffectsController:EnableByString has a success return value that Player::EnableEffect's string overload did not include.