### PR TITLE
Modifying Kicked/Banned events

### DIFF
--- a/Exiled.Events/EventArgs/BannedEventArgs.cs
+++ b/Exiled.Events/EventArgs/BannedEventArgs.cs
@@ -38,7 +38,7 @@ namespace Exiled.Events.EventArgs
         /// Gets the banned player.
         /// </summary>
         [Obsolete("Use Target instead")]
-        public Player Player { get; }
+        public Player Player => Target;
 
         /// <summary>
         /// Gets the banned player.

--- a/Exiled.Events/EventArgs/BannedEventArgs.cs
+++ b/Exiled.Events/EventArgs/BannedEventArgs.cs
@@ -19,20 +19,36 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="BannedEventArgs"/> class.
         /// </summary>
-        /// <param name="player">The banned player.</param>
+        /// <param name="target">The banned player.</param>
+        /// <param name="issuer">The issuer player.</param>
         /// <param name="details">The ban details.</param>
         /// <param name="type"><inheritdoc cref="Type"/></param>
-        public BannedEventArgs(Player player, BanDetails details, BanHandler.BanType type)
+        public BannedEventArgs(Player target, Player issuer, BanDetails details, BanHandler.BanType type)
         {
-            Player = player;
+#pragma warning disable CS0618 // Type or member is obsolete
+            Player = target;
+#pragma warning restore CS0618 // Type or member is obsolete
+            Target = target;
             Details = details;
             Type = type;
+            Issuer = issuer;
         }
 
         /// <summary>
         /// Gets the banned player.
         /// </summary>
+        [Obsolete("Use Target instead")]
         public Player Player { get; }
+
+        /// <summary>
+        /// Gets the banned player.
+        /// </summary>
+        public Player Target { get; }
+
+        /// <summary>
+        /// Gets the issuer player.
+        /// </summary>
+        public Player Issuer { get; }
 
         /// <summary>
         /// Gets the ban details.

--- a/Exiled.Events/EventArgs/BannedEventArgs.cs
+++ b/Exiled.Events/EventArgs/BannedEventArgs.cs
@@ -25,9 +25,6 @@ namespace Exiled.Events.EventArgs
         /// <param name="type"><inheritdoc cref="Type"/></param>
         public BannedEventArgs(Player target, Player issuer, BanDetails details, BanHandler.BanType type)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            Player = target;
-#pragma warning restore CS0618 // Type or member is obsolete
             Target = target;
             Details = details;
             Type = type;

--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -19,12 +19,15 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Initializes a new instance of the <see cref="KickedEventArgs"/> class.
         /// </summary>
-        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="target"><inheritdoc cref="Player"/></param>
         /// <param name="reason"><inheritdoc cref="Reason"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public KickedEventArgs(Player player, string reason, bool isAllowed = true)
+        public KickedEventArgs(Player target, string reason, bool isAllowed = true)
         {
-            Player = player;
+#pragma warning disable CS0618 // Type or member is obsolete
+            Player = target;
+#pragma warning restore CS0618 // Type or member is obsolete
+            Target = target;
             Reason = reason;
             IsAllowed = isAllowed;
         }
@@ -32,7 +35,13 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets the kicked player.
         /// </summary>
+        [Obsolete("Use Target instead")]
         public Player Player { get; }
+
+        /// <summary>
+        /// Gets the kicked player.
+        /// </summary>
+        public Player Target { get; }
 
         /// <summary>
         /// Gets or sets the kick reason.

--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -33,7 +33,7 @@ namespace Exiled.Events.EventArgs
         /// Gets the kicked player.
         /// </summary>
         [Obsolete("Use Target instead")]
-        public Player Player { get; }
+        public Player Player => Target;
 
         /// <summary>
         /// Gets the kicked player.

--- a/Exiled.Events/EventArgs/KickedEventArgs.cs
+++ b/Exiled.Events/EventArgs/KickedEventArgs.cs
@@ -24,9 +24,6 @@ namespace Exiled.Events.EventArgs
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
         public KickedEventArgs(Player target, string reason, bool isAllowed = true)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            Player = target;
-#pragma warning restore CS0618 // Type or member is obsolete
             Target = target;
             Reason = reason;
             IsAllowed = isAllowed;

--- a/Exiled.Events/Patches/Events/Player/Banned.cs
+++ b/Exiled.Events/Patches/Events/Player/Banned.cs
@@ -22,7 +22,7 @@ namespace Exiled.Events.Patches.Events.Player
     {
         private static void Postfix(BanDetails ban, BanHandler.BanType banType)
         {
-            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), ban, banType);
+            var ev = new BannedEventArgs(string.IsNullOrEmpty(ban.Id) ? null : API.Features.Player.Get(ban.Id), API.Features.Player.Get(ban.Issuer), ban, banType);
 
             Player.OnBanned(ev);
         }


### PR DESCRIPTION
* Giving BannedEventArgs a well-deserved issuer (I know it was already there in BanDetails as IssuerId, but I mean we pass the banned player and that's also there)
* Renaming Player to Target in Kicked/Banned event args to keep consistent with Kicking/Banning events (Was more skeptical abt this change but it makes all the events have matching parameters [plus they're still the target of the ban regardless])