### PR TITLE
Adding Lift.Type() extension

### DIFF
--- a/Exiled.API/Enums/ElevatorType.cs
+++ b/Exiled.API/Enums/ElevatorType.cs
@@ -33,7 +33,7 @@ namespace Exiled.API.Enums
         Nuke,
 
         /// <summary>
-        /// Heavy Containment Zone SCP 049 elevator.
+        /// Heavy Containment Zone SCP-049 elevator.
         /// </summary>
         Scp049,
 

--- a/Exiled.API/Extensions/LiftTypeExtension.cs
+++ b/Exiled.API/Extensions/LiftTypeExtension.cs
@@ -1,0 +1,99 @@
+// -----------------------------------------------------------------------
+// <copyright file="LiftTypeExtension.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.API.Extensions
+{
+    using System.Collections.Generic;
+
+    using Exiled.API.Enums;
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains an extension method to get <see cref="ElevatorType"/> from <see cref="Lift"/>.
+    /// Internal class <see cref="RegisterElevatorTypesOnLevelLoad"/> to cache the <see cref="ElevatorType"/> on level load.
+    /// </summary>
+    public static class LiftTypeExtension
+    {
+        private static readonly Dictionary<int, ElevatorType> OrderedElevatorTypes = new Dictionary<int, ElevatorType>();
+
+        /// <summary>
+        /// Gets the <see cref="ElevatorType"/>.
+        /// </summary>
+        /// <param name="lift">The <see cref="Lift"/> to check.</param>
+        /// <returns>The <see cref="ElevatorType"/>.</returns>
+        public static ElevatorType Type(this Lift lift) => OrderedElevatorTypes.TryGetValue(lift.GetInstanceID(), out var elevatorType) ? elevatorType : ElevatorType.Unknown;
+
+        /// <summary>
+        /// Gets all the <see cref="ElevatorType"/> values for for the <see cref="Lift"/> instances using <see cref="Lift.elevatorName"/> and <see cref="UnityEngine.GameObject"/> name.
+        /// </summary>
+        internal static void RegisterElevatorTypesOnLevelLoad()
+        {
+            OrderedElevatorTypes.Clear();
+
+            var lifts = Map.Lifts;
+
+            if (lifts == null)
+                return;
+
+            var liftCount = lifts.Count;
+            for (int i = 0; i < liftCount; i++)
+            {
+                var lift = lifts[i];
+                var liftID = lift.GetInstanceID();
+
+                var liftName = string.IsNullOrWhiteSpace(lift.elevatorName) ? lift.elevatorName.RemoveBracketsOnEndOfName() : lift.elevatorName;
+
+                var elevatorType = GetElevatorType(liftName);
+
+                OrderedElevatorTypes.Add(liftID, elevatorType);
+            }
+        }
+
+        private static ElevatorType GetElevatorType(string elevatorName)
+        {
+            switch (elevatorName)
+            {
+                case "":
+                {
+                    return ElevatorType.Nuke;
+                }
+
+                case "ElA":
+                case "ElA2":
+                {
+                    return ElevatorType.LczA;
+                }
+
+                case "ElB":
+                case "ElB2":
+                {
+                    return ElevatorType.LczB;
+                }
+
+                case "GateA":
+                {
+                    return ElevatorType.GateA;
+                }
+
+                case "GateB":
+                {
+                    return ElevatorType.GateB;
+                }
+
+                case "SCP-049":
+                {
+                    return ElevatorType.Scp049;
+                }
+
+                default:
+                {
+                    return ElevatorType.Unknown;
+                }
+            }
+        }
+    }
+}

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -129,7 +129,10 @@ namespace Exiled.API.Features
             get
             {
                 if (LiftsValue.Count == 0)
+                {
                     LiftsValue.AddRange(Object.FindObjectsOfType<Lift>());
+                    LiftTypeExtension.RegisterElevatorTypesOnLevelLoad();
+                }
 
                 return ReadOnlyLiftsValue;
             }

--- a/Exiled.Events/EventArgs/InteractingElevatorEventArgs.cs
+++ b/Exiled.Events/EventArgs/InteractingElevatorEventArgs.cs
@@ -10,6 +10,7 @@ namespace Exiled.Events.EventArgs
     using System;
 
     using Exiled.API.Enums;
+    using Exiled.API.Extensions;
     using Exiled.API.Features;
 
     /// <summary>
@@ -30,7 +31,9 @@ namespace Exiled.Events.EventArgs
             Player = player;
             Elevator = elevator;
             IsAllowed = isAllowed;
-            Type = GetElevatorType(lift.elevatorName);
+#pragma warning disable CS0618 // Type or member is obsolete
+            Type = lift.Type();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -51,54 +54,12 @@ namespace Exiled.Events.EventArgs
         /// <summary>
         /// Gets the <see cref="ElevatorType"/>.
         /// </summary>
+        [Obsolete("Use Lift.Type() extension method instead.")]
         public ElevatorType Type { get; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the event can be executed or not.
         /// </summary>
         public bool IsAllowed { get; set; }
-
-        private static ElevatorType GetElevatorType(string name)
-        {
-            switch (name)
-            {
-                case "":
-                {
-                    return ElevatorType.Nuke;
-                }
-
-                case "ElA":
-                case "ElA2":
-                {
-                    return ElevatorType.LczA;
-                }
-
-                case "ElB":
-                case "ElB2":
-                {
-                    return ElevatorType.LczB;
-                }
-
-                case "GateA":
-                {
-                    return ElevatorType.GateA;
-                }
-
-                case "GateB":
-                {
-                    return ElevatorType.GateB;
-                }
-
-                case "SCP-049":
-                {
-                    return ElevatorType.Scp049;
-                }
-
-                default:
-                {
-                    return ElevatorType.Unknown;
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Adding Lift.Type() extension to match Door.Type(). Previously, ElevatorType enum was only used in InteractingElevatorEventArgs. Now it can be used anywhere via the Lift.Type() method. I also marked InteractingElevatorEventArgs.Type as obsolete, as the DoorType isn't in the InteractingDoorEventArgs, it shouldn't be here either (now that Lift.Type() is available).