### PR TITLE
Adding Scp079 ChangingCamera event

### DIFF
--- a/Exiled.Events/EventArgs/ChangingCameraEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingCameraEventArgs.cs
@@ -1,0 +1,54 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingCameraEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all informations before a player's intercom mute status is changed.
+    /// </summary>
+    public class ChangingCameraEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingCameraEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="newCamera"><inheritdoc cref="Camera"/></param>
+        /// <param name="manaCost"><inheritdoc cref="APCost"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public ChangingCameraEventArgs(Player player, Camera079 newCamera, float manaCost, bool isAllowed = true)
+        {
+            Player = player;
+            Camera = newCamera;
+            APCost = manaCost;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player who's being intercom muted/unmuted.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets or sets the camera SCP-079 will be moved to.
+        /// </summary>
+        public Camera079 Camera { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount of AP that will be required to switch cameras.
+        /// </summary>
+        public float APCost { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not SCP-079 can switch cameras. Will default to false if SCP-079 does not have enough mana to switch.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/Handlers/Scp079.cs
+++ b/Exiled.Events/Handlers/Scp079.cs
@@ -18,6 +18,11 @@ namespace Exiled.Events.Handlers
     public static class Scp079
     {
         /// <summary>
+        /// Invoked before SCP-079 switches cameras.
+        /// </summary>
+        public static event CustomEventHandler<ChangingCameraEventArgs> ChangingCamera;
+
+        /// <summary>
         /// Invoked before gaining experience with SCP-079
         /// </summary>
         public static event CustomEventHandler<GainingExperienceEventArgs> GainingExperience;
@@ -51,6 +56,12 @@ namespace Exiled.Events.Handlers
         /// Invoked after Scp079 recontainment.
         /// </summary>
         public static event CustomEventHandler<RecontainedEventArgs> Recontained;
+
+        /// <summary>
+        /// Called before SCP-079 switches cameras.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingCameraEventArgs"/> instance.</param>
+        public static void OnChangingCamera(ChangingCameraEventArgs ev) => ChangingCamera.InvokeSafely(ev);
 
         /// <summary>
         /// Called before gaining experience with SCP-079.

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -66,7 +66,7 @@ namespace Exiled.Events.Patches.Events.Scp079
                 {
                     __instance.RpcNotEnoughMana(ev.APCost, __instance.curMana);
                 }
-                
+
                 return false;
             }
             catch (Exception e)

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingCamera.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Scp079
+{
+#pragma warning disable SA1313
+    using System;
+
+    using Exiled.Events.EventArgs;
+    using Exiled.Events.Handlers;
+
+    using HarmonyLib;
+
+    using UnityEngine;
+
+    /// <summary>
+    /// Patches <see cref="Scp079PlayerScript.CallCmdSwitchCamera(ushort, bool)"/>.
+    /// Adds the <see cref="Scp079.ChangingCamera"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(Scp079PlayerScript), nameof(Scp079PlayerScript.CallCmdSwitchCamera))]
+    internal static class ChangingCamera
+    {
+        private static bool Prefix(Scp079PlayerScript __instance, ushort cameraId, bool lookatRotation)
+        {
+            try
+            {
+                if (!__instance._interactRateLimit.CanExecute(true))
+                {
+                    return false;
+                }
+
+                if (!__instance.iAm079)
+                {
+                    return false;
+                }
+
+                Camera079 camera = null;
+                foreach (Camera079 camera2 in Scp079PlayerScript.allCameras)
+                {
+                    if (camera2.cameraId == cameraId)
+                    {
+                        camera = camera2;
+                    }
+                }
+
+                if (camera == null)
+                {
+                    return false;
+                }
+
+                float num = __instance.CalculateCameraSwitchCost(camera.transform.position);
+                bool isAllowed = num <= __instance.curMana;
+                ChangingCameraEventArgs ev = new ChangingCameraEventArgs(API.Features.Player.Get(__instance.gameObject), camera, num, isAllowed);
+                Scp079.OnChangingCamera(ev);
+                if (ev.IsAllowed)
+                {
+                    __instance.RpcSwitchCamera(ev.Camera.cameraId, lookatRotation);
+                    __instance.Mana -= ev.APCost;
+                    __instance.currentCamera = ev.Camera;
+
+                    return false;
+                }
+                else
+                {
+                    if (ev.APCost > __instance.curMana)
+                    {
+                        __instance.RpcNotEnoughMana(ev.APCost, __instance.curMana);
+                        return false;
+                    }
+
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Exiled.API.Features.Log.Error($"{typeof(ChangingCamera).FullName}.{nameof(Prefix)}:\n{e}");
+
+                return true;
+            }
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -61,19 +61,13 @@ namespace Exiled.Events.Patches.Events.Scp079
                     __instance.RpcSwitchCamera(ev.Camera.cameraId, lookatRotation);
                     __instance.Mana -= ev.APCost;
                     __instance.currentCamera = ev.Camera;
-
-                    return false;
                 }
-                else
+                else if (ev.APCost > __instance.curMana)
                 {
-                    if (ev.APCost > __instance.curMana)
-                    {
-                        __instance.RpcNotEnoughMana(ev.APCost, __instance.curMana);
-                        return false;
-                    }
-
-                    return false;
+                    __instance.RpcNotEnoughMana(ev.APCost, __instance.curMana);
                 }
+                
+                return false;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Scp079::ChangingCamera event - Patches `CallCmdSwitchCamera`, invokes before SCP-079 switches to a different camera.