### PR TITLE
Shortening ChangingCamera patch

### DIFF
--- a/Exiled.Events/EventArgs/ChangingCameraEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingCameraEventArgs.cs
@@ -47,7 +47,9 @@ namespace Exiled.Events.EventArgs
         public float APCost { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not SCP-079 can switch cameras. Will default to false if SCP-079 does not have enough mana to switch.
+        /// Gets or sets a value indicating whether or not SCP-079 can switch cameras.
+        /// Defaults to a value describing whether or not SCP-079 has enough AP to switch.
+        /// Can be set to true to allow a switch regardless of SCP-079's AP amount.
         /// </summary>
         public bool IsAllowed { get; set; }
     }

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -38,14 +38,7 @@ namespace Exiled.Events.Patches.Events.Scp079
                     return false;
                 }
 
-                Camera079 camera = null;
-                foreach (Camera079 camera2 in Scp079PlayerScript.allCameras)
-                {
-                    if (camera2.cameraId == cameraId)
-                    {
-                        camera = camera2;
-                    }
-                }
+                Camera079 camera = API.Features.Map.GetCameraById(cameraId);
 
                 if (camera == null)
                 {

--- a/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
+++ b/Exiled.Events/Patches/Events/Scp079/ChangingCamera.cs
@@ -52,7 +52,7 @@ namespace Exiled.Events.Patches.Events.Scp079
                 if (ev.IsAllowed)
                 {
                     __instance.RpcSwitchCamera(ev.Camera.cameraId, lookatRotation);
-                    __instance.Mana -= ev.APCost;
+                    __instance.Mana = Mathf.Clamp(__instance.Mana - ev.APCost, 0, __instance.maxMana);
                     __instance.currentCamera = ev.Camera;
                 }
                 else if (ev.APCost > __instance.curMana)


### PR DESCRIPTION
Now that `Map::GetCameraById` is a thing, I've shortened the ChangingCamera patch to use this method