### PR TITLE
Allowing users with bypass mode to open locked door (base game feature).

### DIFF
--- a/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
+++ b/Exiled.Events/Patches/Events/Player/InteractingDoor.cs
@@ -80,7 +80,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 Handlers.Player.OnInteractingDoor(ev);
 
-                if (ev.IsAllowed && !ev.Door.locked)
+                if (ev.IsAllowed && (!ev.Door.locked || __instance._sr.BypassMode))
                     ev.Door.ChangeState(__instance._sr.BypassMode);
                 else
                     __instance.RpcDenied(doorId);


### PR DESCRIPTION
* Base game feature: Users with bypass mode can open locked doors, exiled was overriding this feature with our InteractingDoor patch
* If a plugin sets `IsAllowed` to `false`, they still will not be able to open the door regardless of bypass mode.

Issue #348.