### PR TITLE
More 079 crap

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -311,6 +311,14 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// gets the camera with the given camera type.
+        /// </summary>
+        /// <param name="cameraType">The <see cref="CameraType"/> to search for.</param>
+        /// <returns>The <see cref="Camera079"/> with the given camera type.</returns>
+        public static Camera079 GetCameraByType(CameraType cameraType) =>
+            GetCameraById((ushort)cameraType);
+
+        /// <summary>
         /// Clears the lazy loading game object cache.
         /// </summary>
         internal static void ClearCache()

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -311,7 +311,7 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// gets the camera with the given camera type.
+        /// Gets the camera with the given camera type.
         /// </summary>
         /// <param name="cameraType">The <see cref="CameraType"/> to search for.</param>
         /// <returns>The <see cref="Camera079"/> with the given camera type.</returns>

--- a/Exiled.Events/EventArgs/ElevatorTeleportEventArgs.cs
+++ b/Exiled.Events/EventArgs/ElevatorTeleportEventArgs.cs
@@ -1,0 +1,55 @@
+// -----------------------------------------------------------------------
+// <copyright file="ElevatorTeleportEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all informations before SCP-079 changes rooms via elevator.
+    /// </summary>
+    public class ElevatorTeleportEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElevatorTeleportEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="camera"><inheritdoc cref="Camera"/></param>
+        /// <param name="apCost"><inheritdoc cref="APCost"/></param>
+        /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
+        public ElevatorTeleportEventArgs(Player player, Camera079 camera, float apCost, bool isAllowed = true)
+        {
+            Player = player;
+            Camera = camera;
+            APCost = apCost;
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the player who is controlling SCP-079.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Camera079"/> that SCP-079 will be moved to.
+        /// </summary>
+        public Camera079 Camera { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount of AP will be consumed during the level change.
+        /// </summary>
+        public float APCost { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not SCP-079 can teleport.
+        /// Defaults to a <see cref="bool"/> describing whether or not SCP-079 has enough AP to teleport.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/Exiled.Events/Handlers/Scp079.cs
+++ b/Exiled.Events/Handlers/Scp079.cs
@@ -43,6 +43,11 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<InteractingDoorEventArgs> InteractingDoor;
 
         /// <summary>
+        /// Invoked before SCP-079 teleports using an elevator.
+        /// </summary>
+        public static event CustomEventHandler<ElevatorTeleportEventArgs> ElevatorTeleport;
+
+        /// <summary>
         /// Invoked before SCP-079 uses a speaker.
         /// </summary>
         public static event CustomEventHandler<StartingSpeakerEventArgs> StartingSpeaker;
@@ -86,6 +91,12 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="InteractingDoorEventArgs"/> instance.</param>
         public static void OnInteractingDoor(InteractingDoorEventArgs ev) => InteractingDoor.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before SCP-079 teleports using an elevator.
+        /// </summary>
+        /// <param name="ev">The <see cref="ElevatorTeleportEventArgs"/> instance.</param>
+        public static void OnElevatorTeleport(ElevatorTeleportEventArgs ev) => ElevatorTeleport.InvokeSafely(ev);
 
         /// <summary>
         /// Called before interacting with a speaker with SCP-079.

--- a/Exiled.Events/Patches/Events/Scp079/Interacting.cs
+++ b/Exiled.Events/Patches/Events/Scp079/Interacting.cs
@@ -247,6 +247,45 @@ namespace Exiled.Events.Patches.Events.Scp079
                             break;
                         }
 
+                    case "ELEVATORTELEPORT":
+                        float manaFromLabel = __instance.GetManaFromLabel("Elevator Teleport", __instance.abilities);
+                        global::Camera079 camera = null;
+                        foreach (global::Scp079Interactable scp079Interactable in __instance.nearbyInteractables)
+                        {
+                            if (scp079Interactable.type == global::Scp079Interactable.InteractableType.ElevatorTeleport)
+                            {
+                                camera = scp079Interactable.optionalObject.GetComponent<global::Camera079>();
+                            }
+                        }
+
+                        if (camera != null)
+                        {
+                            ElevatorTeleportEventArgs ev = new ElevatorTeleportEventArgs(Player.Get(__instance.gameObject), camera, manaFromLabel, manaFromLabel <= __instance.curMana);
+
+                            Handlers.Scp079.OnElevatorTeleport(ev);
+
+                            if (ev.IsAllowed)
+                            {
+                                __instance.RpcSwitchCamera(ev.Camera.cameraId, false);
+                                __instance.Mana -= ev.APCost;
+                                __instance.AddInteractionToHistory(target, array[0], true);
+                                result = false;
+                                break;
+                            }
+                            else
+                            {
+                                if (ev.APCost > __instance.curMana)
+                                {
+                                    __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                    result = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        result = false;
+                        break;
+
                     default:
                         result = true;
                         break;

--- a/Exiled.Events/Patches/Events/Scp079/Interacting.cs
+++ b/Exiled.Events/Patches/Events/Scp079/Interacting.cs
@@ -269,16 +269,12 @@ namespace Exiled.Events.Patches.Events.Scp079
                                 __instance.RpcSwitchCamera(ev.Camera.cameraId, false);
                                 __instance.Mana -= ev.APCost;
                                 __instance.AddInteractionToHistory(target, array[0], true);
-                                result = false;
-                                break;
                             }
                             else
                             {
                                 if (ev.APCost > __instance.curMana)
                                 {
                                     __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
-                                    result = false;
-                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
* `ElevatorTeleport` event: Invoked before Scp-079 switches floors using elevators. Event args take player, camera, ap amount, and isAllowed
* Adding `Map::GetCameraByType(CameraType)` - Returns a `Camera079` with the given CameraType