### PR TITLE
Creating events for sneak and sprint

### DIFF
--- a/Exiled.Events/EventArgs/ChangingSneakEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingSneakEventArgs.cs
@@ -19,7 +19,7 @@ namespace Exiled.Events.EventArgs
         /// Initializes a new instance of the <see cref="ChangingSneakEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
-        /// <param name="isSneaking"><inheritdoc cref="IsSprinting"/></param>
+        /// <param name="isSneaking"><inheritdoc cref="IsSneaking"/></param>
         public ChangingSneakEventArgs(Player player, bool isSneaking)
         {
             Player = player;

--- a/Exiled.Events/EventArgs/ChangingSneakEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingSneakEventArgs.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingSneakEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all informations before a player starts or stops sneaking.
+    /// </summary>
+    public class ChangingSneakEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingSneakEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="isSneaking"><inheritdoc cref="IsSprinting"/></param>
+        public ChangingSneakEventArgs(Player player, bool isSneaking)
+        {
+            Player = player;
+            IsSneaking = isSneaking;
+        }
+
+        /// <summary>
+        /// Gets the player who is starting/stopping sneaking.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the player started or stopped sneaking.
+        /// </summary>
+        public bool IsSneaking { get; }
+    }
+}

--- a/Exiled.Events/EventArgs/ChangingSprintEventArgs.cs
+++ b/Exiled.Events/EventArgs/ChangingSprintEventArgs.cs
@@ -1,0 +1,39 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingSprintEventArgs.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs
+{
+    using System;
+    using Exiled.API.Features;
+
+    /// <summary>
+    /// Contains all informations before a player starts or stops sprinting.
+    /// </summary>
+    public class ChangingSprintEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangingSprintEventArgs"/> class.
+        /// </summary>
+        /// <param name="player"><inheritdoc cref="Player"/></param>
+        /// <param name="isSprinting"><inheritdoc cref="IsSprinting"/></param>
+        public ChangingSprintEventArgs(Player player, bool isSprinting)
+        {
+            Player = player;
+            IsSprinting = isSprinting;
+        }
+
+        /// <summary>
+        /// Gets the player who is starting/stopping sprinting.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the player started or stopped sprinting.
+        /// </summary>
+        public bool IsSprinting { get; }
+    }
+}

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -211,6 +211,16 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<ChangingGroupEventArgs> ChangingGroup;
 
         /// <summary>
+        /// Invoked before a player starts or stops sprinting.
+        /// </summary>
+        public static event CustomEventHandler<ChangingSprintEventArgs> ChangingSprint;
+
+        /// <summary>
+        /// Invoked before a player starts or stops sneaking.
+        /// </summary>
+        public static event CustomEventHandler<ChangingSneakEventArgs> ChangingSneak;
+
+        /// <summary>
         /// Invoked before a player interacts with a door.
         /// </summary>
         public static event CustomEventHandler<InteractingDoorEventArgs> InteractingDoor;
@@ -501,6 +511,18 @@ namespace Exiled.Events.Handlers
         /// </summary>
         /// <param name="ev">The <see cref="ChangingItemEventArgs"/> instance.</param>
         public static void OnChangingItem(ChangingItemEventArgs ev) => ChangingItem.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a player starts or stops sprinting.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingSprintEventArgs"/> instance.</param>
+        public static void OnChangingSprint(ChangingSprintEventArgs ev) => ChangingSprint.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before a player starts or stops sneaking.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChangingSneakEventArgs"/> instance.</param>
+        public static void OnChangingSneak(ChangingSneakEventArgs ev) => ChangingSneak.InvokeSafely(ev);
 
         /// <summary>
         /// Called before changing a player's group.

--- a/Exiled.Events/Patches/Events/Player/ChangingSneak.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingSneak.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingSneak.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1313
+
+    using Exiled.Events.EventArgs;
+    using Exiled.Events.Handlers;
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="FirstPersonController.IsSneaking"/>.
+    /// Adds the <see cref="Player.ChangingSneak"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(FirstPersonController), nameof(FirstPersonController.IsSneaking), MethodType.Setter)]
+    internal static class ChangingSneak
+    {
+        private static void Prefix(FirstPersonController __instance, bool value)
+        {
+            var ev = new ChangingSneakEventArgs(API.Features.Player.Get(__instance.hub), value);
+
+            Player.OnChangingSneak(ev);
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/ChangingSprint.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingSprint.cs
@@ -1,0 +1,31 @@
+// -----------------------------------------------------------------------
+// <copyright file="ChangingSprint.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+#pragma warning disable SA1313
+
+    using Exiled.Events.EventArgs;
+    using Exiled.Events.Handlers;
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="Stamina._isSprinting"/>.
+    /// Adds the <see cref="Player.ChangingSprint"/> event.
+    /// </summary>
+    [HarmonyPatch(typeof(Stamina), nameof(Stamina._isSprinting), MethodType.Setter)]
+    internal static class ChangingSprint
+    {
+        private static void Prefix(Stamina __instance, bool value)
+        {
+            var ev = new ChangingSprintEventArgs(API.Features.Player.Get(__instance._hub), value);
+
+            Player.OnChangingSprint(ev);
+        }
+    }
+}


### PR DESCRIPTION
* `ChangingSprint` - Fires when a player starts or stops sprinting
* `ChangingSneak` - Ditto, but with crouching/sneaking

Events don't currently have IsAlloweds, as changing the parameter doesn't affect anything (however, when the client starts/stops sprinting and sneaking, the variable does change which is why I can patch it). I'm not sure if this is possible or not.