### PR TITLE
Added new Map::SpawnRagdoll methods

### DIFF
--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -253,6 +253,36 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Spawns a ragdoll for a player on a certain position.
+        /// </summary>
+        /// <param name="victim">Victim, represented as a player.</param>
+        /// <param name="deathCause">The message to be displayed as his death.</param>
+        /// <param name="position">Where the ragdoll will be spawned.</param>
+        /// <param name="rotation">The rotation for the ragdoll.</param>
+        /// <param name="velocity">The initial velocity the ragdoll will have, as if it was exploded.</param>
+        /// <param name="allowRecall">Sets this ragdoll as respawnable by SCP-049.</param>
+        /// <returns>The Ragdoll component (requires Assembly-CSharp to be referenced).</returns>
+        public static global::Ragdoll SpawnRagdoll(
+                Player victim,
+                DamageTypes.DamageType deathCause,
+                Vector3 position,
+                Quaternion rotation = default,
+                Vector3 velocity = default,
+                bool allowRecall = true)
+        {
+            return SpawnRagdoll(
+                        victim.Role,
+                        deathCause,
+                        victim.DisplayNickname,
+                        position,
+                        rotation,
+                        velocity,
+                        allowRecall,
+                        victim.Id,
+                        victim.GameObject.GetComponent<Dissonance.Integrations.MirrorIgnorance.MirrorIgnorancePlayer>().PlayerId);
+        }
+
+        /// <summary>
         /// Spawns a ragdoll on the map based on the different arguments.
         /// </summary>
         /// <remarks>

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -168,7 +168,8 @@ namespace Exiled.API.Features
 
         /// <summary>
         /// Gets the Default <see cref="Ragdoll.Info"/>,
-        /// used in <see cref="SpawnRagdoll(RoleType, string, Vector3, Quaternion, Vector3, PlayerStats.HitInfo, bool, int, string)"/>.
+        /// used in <see cref="SpawnRagdoll(RoleType, string, PlayerStats.HitInfo, Vector3, Quaternion, Vector3, bool, int, string)"/>
+        /// and <see cref="SpawnRagdoll(global::Role, Ragdoll.Info, Vector3, Quaternion, Vector3, bool)"/>.
         /// </summary>
         /// <remarks>
         /// This value can be modified to change the default Ragdoll's info.
@@ -419,7 +420,7 @@ namespace Exiled.API.Features
 
             // Modify the Ragdoll's component
             global::Ragdoll ragdollObject = gameObject.GetComponent<global::Ragdoll>();
-            ragdollObject.Networkowner = ragdollInfo;
+            ragdollObject.Networkowner = ragdollInfo != null ? ragdollInfo : DefaultRagdollOwner;
             ragdollObject.NetworkallowRecall = allowRecall;
             ragdollObject.NetworkPlayerVelo = velocity;
 

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -353,14 +353,6 @@ namespace Exiled.API.Features
             if (role.model_ragdoll == null)
                 return null;
             var @default = DefaultRagdollOwner;
-            /* // Uncomment if people complain that changing
-             * // DefaultRagdollOwner.DeathCause changes
-             * // already spawned ragdolls.
-            if (hitInfo == default)
-            {
-                hitInfo = new PlayerStats.HitInfo(hitInfo.Amount, hitInfo.Attacker, DamageTypes.FromWeaponId(hitInfo.Tool), hitInfo.PlayerId);
-            }
-            */
 
             var ragdollInfo = new Ragdoll.Info()
             {

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -339,6 +339,14 @@ namespace Exiled.API.Features
             if (role.model_ragdoll == null)
                 return null;
             var @default = DefaultRagdollOwner;
+            /* // Uncomment if people complain that changing
+             * // DefaultRagdollOwner.DeathCause changes
+             * // already spawned ragdolls.
+            if (hitInfo == default)
+            {
+                hitInfo = new PlayerStats.HitInfo(hitInfo.Amount, hitInfo.Attacker, DamageTypes.FromWeaponId(hitInfo.Tool), hitInfo.PlayerId);
+            }
+            */
 
             var ragdollInfo = new Ragdoll.Info()
             {

--- a/Exiled.API/Features/Map.cs
+++ b/Exiled.API/Features/Map.cs
@@ -179,7 +179,8 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
-        /// Gets the Default <see cref="Ragdoll.Info"/>, used in <see cref="SpawnRagdoll()"/>.
+        /// Gets the Default <see cref="Ragdoll.Info"/>,
+        /// used in <see cref="SpawnRagdoll(RoleType, string, Vector3, Quaternion, Vector3, PlayerStats.HitInfo, bool, int, string)"/>.
         /// </summary>
         /// <remarks>
         /// This value can be modified to change the default Ragdoll's info.
@@ -262,13 +263,7 @@ namespace Exiled.API.Features
         /// <param name="velocity">The initial velocity the ragdoll will have, as if it was exploded.</param>
         /// <param name="allowRecall">Sets this ragdoll as respawnable by SCP-049.</param>
         /// <returns>The Ragdoll component (requires Assembly-CSharp to be referenced).</returns>
-        public static global::Ragdoll SpawnRagdoll(
-                Player victim,
-                DamageTypes.DamageType deathCause,
-                Vector3 position,
-                Quaternion rotation = default,
-                Vector3 velocity = default,
-                bool allowRecall = true)
+        public static global::Ragdoll SpawnRagdoll(Player victim, DamageTypes.DamageType deathCause, Vector3 position, Quaternion rotation = default, Vector3 velocity = default, bool allowRecall = true)
         {
             return SpawnRagdoll(
                         victim.Role,
@@ -402,7 +397,7 @@ namespace Exiled.API.Features
         /// EXILED already has an internal, default Ragdoll.Info: the use of this
         /// method to try to optimize a plugin is absolutely optional.
         /// </para>
-        /// We recommend using: <see cref="SpawnRagdoll(RoleType, Vector3)"/>
+        /// We recommend using: Map.SpawnRagdoll(RoleType roleType, string victimNick, Vector3 position)
         /// </item>
         /// <item>
         /// This method should only ever be used if you're dealing with massive


### PR DESCRIPTION
# Changelog

- `Map::SpawnRagdoll(Player victim, DamageTypes.DamageType deathCause, Vector3 position, Quaternion rotation = default, Vector3 velocity = default, bool allowRecall = true)`

Spawns a ragdoll for a player (useful if: 1. Ragdolls aren't really spawned after a round restart; 2. You want SCP-049 to be able to respawn them.)

- `Map::SpawnRagdoll( RoleType roleType, DamageTypes.DamageType deathCause, string victimNick, Vector3 position, Quaternion rotation = default, Vector3 velocity = default, bool allowRecall = false, int playerId = -1, string mirrorOwnerId = null, float damage = -1f, string killerName = "Killer", int killerId = -1)`

Spawns a ragdoll based on a series of parameters. Most of them aren't actually used, but some other plugins might use them, so I felt like it was a good idea to keeping them there. The `HitInfo` used by the ragdoll's death cause is split into different parameters, so you don't have to manually do `new PlayerStats.HitInfo` *if you don't want to*.

- `Map::SpawnRagdoll(RoleType roleType, string victimNick, Vector3 position, Quaternion rotation = default, Vector3 velocity = default, global::PlayerStats.HitInfo hitInfo = default, bool allowRecall = false, int playerId = -1, string mirrorOwnerId = null)`

Another big boy method where half of the parameters don't matter, but the `HitInfo` is squashed into one variable instead of split into different optional parameters like the overload above.

- `Map::SpawnRagdoll(global::Role role, Ragdoll.Info ragdollInfo, Vector3 position, Quaternion rotation = default, Vector3 velocity = default, bool allowRecall = false)`

Uses the main game's parameters so you can re-use pre-loaded objects: every other method uses the logic in this one, this is its main purpose. Perfect if EXILED ever needs to change the code, or if someone wants to implement their own SpawnRagdoll which could call this one so, for example, every ragdoll has the same settings.

## Remarks
I haven't been able to *really* test the new methods and they are pretty weird to work with since the overloads are slightly messed up. Either way, the only "problem" I'd see would be the `mirrorOwnerID` field.

My suggestion, if ragdolls stop spawning through this method after a round restart, is to just stop using the `DefaultRagdollInfo` property and then just do the `GetComponent` every time this command gets called: I just don't know if this is necessary. Either way, you could always spawn a ragdoll for a player using `SpawnRagdoll(Player, DamageTypes.DamageType, Vector3)`, and this is 99% guaranteed to work.