### PR TITLE
Adding IsEnabled support into show plugins command

### DIFF
--- a/Exiled.Events/Commands/Show/Plugins.cs
+++ b/Exiled.Events/Commands/Show/Plugins.cs
@@ -47,9 +47,13 @@ namespace Exiled.Events.Commands.Show
             sb.AppendLine();
 
             var plugins = Exiled.Loader.Loader.Plugins;
+            var enabledPluginCount = plugins.Where(plugin => plugin.Config.IsEnabled).Count();
 
             // Append two new lines before the list
-            sb.Append("Total number of plugins: ").Append(plugins.Count).AppendLine().AppendLine();
+            sb.Append("Total number of plugins: ").Append(plugins.Count).AppendLine()
+                .Append("Enabled plugins: ").Append(enabledPluginCount).AppendLine()
+                .Append("Disabled plugins: ").Append(plugins.Count - enabledPluginCount)
+                .AppendLine().AppendLine();
 
             StringBuilder AppendNewRow() => sb.AppendLine().Append("\t");
 
@@ -58,6 +62,11 @@ namespace Exiled.Events.Commands.Show
                 var plugin = plugins.ElementAt(z);
 
                 sb.Append(string.IsNullOrEmpty(plugin.Name) ? "(Unknown)" : plugin.Name).Append(":");
+
+                if (!plugin.Config.IsEnabled)
+                {
+                    AppendNewRow().Append("- Disabled");
+                }
 
                 AppendNewRow().Append("- Author: ").Append(plugin.Author);
                 AppendNewRow().Append("- Version: ").Append(plugin.Version);


### PR DESCRIPTION
* Shows amount of enabled and disabled plugins at the top
* Disabled plugins will now show `- Disabled` underneath the name

Figured this might help with some people narrowing down why their plugin isn't working (as this command previously didn't explicitly show whether a plugin was enabled or not