### PR TITLE
Proper call order for common events

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -209,6 +209,14 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Gets a value indicating whether or not the player is verified.
+        /// </summary>
+        /// <remarks>
+        /// This is always false if online_mode is set to false.
+        /// </remarks>
+        public bool IsVerified { get; internal set; }
+
+        /// <summary>
         /// Gets or sets the player's display nickname.
         /// May be null.
         /// </summary>

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -432,7 +432,7 @@ namespace Exiled.API.Features
         /// <summary>
         /// Gets a value indicating whether or not the player is the host.
         /// </summary>
-        public bool IsHost => ReferenceHub.characterClassManager.IsHost;
+        public bool IsHost => ReferenceHub.isDedicatedServer;
 
         /// <summary>
         /// Gets a value indicating whether or not the player is alive.

--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -399,13 +399,9 @@ namespace Exiled.API.Features
         public bool IsJumping => ReferenceHub.animationController.curAnim == 2;
 
         /// <summary>
-        /// Gets or sets the player's IP address.
+        /// Gets the player's IP address.
         /// </summary>
-        public string IPAddress
-        {
-            get => ReferenceHub.queryProcessor._ipAddress;
-            set => ReferenceHub.queryProcessor._ipAddress = value;
-        }
+        public string IPAddress => ReferenceHub.networkIdentity.connectionToClient.address;
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the <see cref="Player"/> has No-clip enabled.

--- a/Exiled.Events/EventArgs/DestoryingEventArgs.cs
+++ b/Exiled.Events/EventArgs/DestoryingEventArgs.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="JoinedEventArgs.cs" company="Exiled Team">
+// <copyright file="DestoryingEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
@@ -12,18 +12,18 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations after a player joins the server.
+    /// Contains all informations before a player's object is destroyed.
     /// </summary>
-    public class JoinedEventArgs : EventArgs
+    public class DestoryingEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="JoinedEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="DestoryingEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
-        public JoinedEventArgs(Player player) => Player = player;
+        public DestoryingEventArgs(Player player) => Player = player;
 
         /// <summary>
-        /// Gets the joined player.
+        /// Gets the destoying player.
         /// </summary>
         public Player Player { get; }
     }

--- a/Exiled.Events/EventArgs/DestroyingEventArgs.cs
+++ b/Exiled.Events/EventArgs/DestroyingEventArgs.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="DestoryingEventArgs.cs" company="Exiled Team">
+// <copyright file="DestroyingEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
@@ -14,13 +14,13 @@ namespace Exiled.Events.EventArgs
     /// <summary>
     /// Contains all informations before a player's object is destroyed.
     /// </summary>
-    public class DestoryingEventArgs : EventArgs
+    public class DestroyingEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DestoryingEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="DestroyingEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
-        public DestoryingEventArgs(Player player) => Player = player;
+        public DestroyingEventArgs(Player player) => Player = player;
 
         /// <summary>
         /// Gets the destoying player.

--- a/Exiled.Events/EventArgs/LeftEventArgs.cs
+++ b/Exiled.Events/EventArgs/LeftEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="LeftEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.

--- a/Exiled.Events/EventArgs/VerifiedEventArgs.cs
+++ b/Exiled.Events/EventArgs/VerifiedEventArgs.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="JoinedEventArgs.cs" company="Exiled Team">
+// <copyright file="VerifiedEventArgs.cs" company="Exiled Team">
 // Copyright (c) Exiled Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
@@ -12,18 +12,18 @@ namespace Exiled.Events.EventArgs
     using Exiled.API.Features;
 
     /// <summary>
-    /// Contains all informations after a player joins the server.
+    /// Contains all informations after the server verifies a player.
     /// </summary>
-    public class JoinedEventArgs : EventArgs
+    public class VerifiedEventArgs : EventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="JoinedEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="VerifiedEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
-        public JoinedEventArgs(Player player) => Player = player;
+        public VerifiedEventArgs(Player player) => Player = player;
 
         /// <summary>
-        /// Gets the joined player.
+        /// Gets the verified player.
         /// </summary>
         public Player Player { get; }
     }

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -80,9 +80,19 @@ namespace Exiled.Events.Handlers
         public static event CustomEventHandler<JoinedEventArgs> Joined;
 
         /// <summary>
+        /// Ivoked after a player has been verified.
+        /// </summary>
+        public static event CustomEventHandler<VerifiedEventArgs> Verified;
+
+        /// <summary>
         /// Invoked after a player has left the server.
         /// </summary>
         public static event CustomEventHandler<LeftEventArgs> Left;
+
+        /// <summary>
+        /// Invoked before destroying a player.
+        /// </summary>
+        public static event CustomEventHandler<DestoryingEventArgs> Destroying;
 
         /// <summary>
         /// Invoked before hurting a player.
@@ -348,10 +358,22 @@ namespace Exiled.Events.Handlers
         public static void OnJoined(JoinedEventArgs ev) => Joined.InvokeSafely(ev);
 
         /// <summary>
+        /// Called after a player has been verified.
+        /// </summary>
+        /// <param name="ev">The <see cref="VerifiedEventArgs"/> instance.</param>
+        public static void OnVerified(VerifiedEventArgs ev) => Verified.InvokeSafely(ev);
+
+        /// <summary>
         /// Called after a player has left the server.
         /// </summary>
         /// <param name="ev">The <see cref="LeftEventArgs"/> instance.</param>
         public static void OnLeft(LeftEventArgs ev) => Left.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called before destroying a player.
+        /// </summary>
+        /// <param name="ev">The <see cref="DestoryingEventArgs"/> instance.</param>
+        public static void OnDestroying(DestoryingEventArgs ev) => Destroying.InvokeSafely(ev);
 
         /// <summary>
         /// Called before hurting a player.

--- a/Exiled.Events/Handlers/Player.cs
+++ b/Exiled.Events/Handlers/Player.cs
@@ -92,7 +92,7 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Invoked before destroying a player.
         /// </summary>
-        public static event CustomEventHandler<DestoryingEventArgs> Destroying;
+        public static event CustomEventHandler<DestroyingEventArgs> Destroying;
 
         /// <summary>
         /// Invoked before hurting a player.
@@ -372,8 +372,8 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Called before destroying a player.
         /// </summary>
-        /// <param name="ev">The <see cref="DestoryingEventArgs"/> instance.</param>
-        public static void OnDestroying(DestoryingEventArgs ev) => Destroying.InvokeSafely(ev);
+        /// <param name="ev">The <see cref="DestroyingEventArgs"/> instance.</param>
+        public static void OnDestroying(DestroyingEventArgs ev) => Destroying.InvokeSafely(ev);
 
         /// <summary>
         /// Called before hurting a player.

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -37,6 +37,7 @@ namespace Exiled.Events.Patches.Events.Player
 
                 PlayerAPI.Dictionary.Remove(player.GameObject);
                 PlayerAPI.IdsCache.Remove(player.Id);
+                PlayerAPI.UserIdsCache.Remove(player.UserId);
             }
             catch (Exception ex)
             {

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -33,7 +33,7 @@ namespace Exiled.Events.Patches.Events.Player
                 if (player == null)
                     return;
 
-                PlayerEvents.OnDestroying(new DestoryingEventArgs(player));
+                PlayerEvents.OnDestroying(new DestroyingEventArgs(player));
 
                 PlayerAPI.Dictionary.Remove(player.GameObject);
                 PlayerAPI.IdsCache.Remove(player.Id);

--- a/Exiled.Events/Patches/Events/Player/Destroying.cs
+++ b/Exiled.Events/Patches/Events/Player/Destroying.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+// <copyright file="Destroying.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System;
+
+    using Exiled.API.Features;
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    using PlayerAPI = Exiled.API.Features.Player;
+    using PlayerEvents = Exiled.Events.Handlers.Player;
+
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+
+    [HarmonyPatch(typeof(ReferenceHub), nameof(ReferenceHub.OnDestroy))]
+    internal static class Destroying
+    {
+        private static void Prefix(ReferenceHub __instance)
+        {
+            try
+            {
+                var player = PlayerAPI.Get(__instance);
+
+                // Means it's the server
+                if (player == null)
+                    return;
+
+                PlayerEvents.OnDestroying(new DestoryingEventArgs(player));
+
+                PlayerAPI.Dictionary.Remove(player.GameObject);
+                PlayerAPI.IdsCache.Remove(player.Id);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"{typeof(Destroying).FullName}.{nameof(Prefix)}:\n{ex}");
+            }
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -15,6 +15,8 @@ namespace Exiled.Events.Patches.Events.Player
 
     using HarmonyLib;
 
+    using Mirror;
+
     using PlayerAPI = Exiled.API.Features.Player;
     using PlayerEvents = Exiled.Events.Handlers.Player;
 
@@ -29,7 +31,8 @@ namespace Exiled.Events.Patches.Events.Player
         {
             try
             {
-                if (__instance.isDedicatedServer)
+                // ReferenceHub is a component that is loaded first
+                if (__instance.isDedicatedServer || ReferenceHub.HostHub == null || PlayerManager.localPlayer == null)
                     return;
 
                 var player = new PlayerAPI(__instance);

--- a/Exiled.Events/Patches/Events/Player/Joined.cs
+++ b/Exiled.Events/Patches/Events/Player/Joined.cs
@@ -10,54 +10,36 @@ namespace Exiled.Events.Patches.Events.Player
 #pragma warning disable SA1313
     using System;
 
+    using Exiled.API.Features;
     using Exiled.Events.EventArgs;
-    using Exiled.Events.Handlers;
-    using Exiled.Loader.Features;
 
     using HarmonyLib;
 
-    using MEC;
+    using PlayerAPI = Exiled.API.Features.Player;
+    using PlayerEvents = Exiled.Events.Handlers.Player;
 
     /// <summary>
-    /// Patches <see cref="ServerRoles.CallCmdServerSignatureComplete(string, string, string, bool)"/>.
-    /// Adds the <see cref="Player.Joined"/> event.
+    /// Patches <see cref="ReferenceHub.Awake"/>.
+    /// Adds the <see cref="PlayerEvents.Joined"/> event.
     /// </summary>
-    [HarmonyPatch(typeof(ServerRoles), nameof(ServerRoles.CallCmdServerSignatureComplete))]
+    [HarmonyPatch(typeof(ReferenceHub), nameof(ReferenceHub.Awake))]
     internal static class Joined
     {
-        private static void Postfix(ServerRoles __instance)
+        private static void Postfix(ReferenceHub __instance)
         {
             try
             {
-                // It means the client has failed the verification
-                if (!__instance.PublicKeyAccepted)
+                if (__instance.isDedicatedServer)
                     return;
 
-                // Allow only one call to this event
-                if (API.Features.Player.Dictionary.ContainsKey(__instance.gameObject))
-                    return;
+                var player = new PlayerAPI(__instance);
+                PlayerAPI.Dictionary.Add(__instance.gameObject, player);
 
-                var player = new API.Features.Player(ReferenceHub.GetHub(__instance.gameObject));
-                API.Features.Player.Dictionary.Add(__instance.gameObject, player);
-
-                API.Features.Log.SendRaw($"Player {player?.Nickname} ({player?.UserId}) ({player?.Id}) connected with the IP: {player?.IPAddress}", ConsoleColor.Green);
-
-                if (PlayerManager.players.Count >= CustomNetworkManager.slots)
-                    MultiAdminFeatures.CallEvent(MultiAdminFeatures.EventType.SERVER_FULL);
-
-                Timing.CallDelayed(0.25f, () =>
-                {
-                    if (player?.IsMuted == true)
-                        player.ReferenceHub.characterClassManager.SetDirtyBit(2UL);
-                });
-
-                var ev = new JoinedEventArgs(API.Features.Player.Get(__instance.gameObject));
-
-                Player.OnJoined(ev);
+                PlayerEvents.OnJoined(new JoinedEventArgs(player));
             }
             catch (Exception exception)
             {
-                API.Features.Log.Error($"{typeof(Joined).FullName}:\n{exception}");
+                Log.Error($"{typeof(Joined).FullName}:\n{exception}");
             }
         }
     }

--- a/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -1,0 +1,64 @@
+// -----------------------------------------------------------------------
+// <copyright file="Verified.cs" company="Exiled Team">
+// Copyright (c) Exiled Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.Patches.Events.Player
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Reflection.Emit;
+
+    using Exiled.API.Features;
+
+    using Exiled.Events.EventArgs;
+
+    using HarmonyLib;
+
+    using PlayerAPI = Exiled.API.Features.Player;
+    using PlayerEvents = Exiled.Events.Handlers.Player;
+
+#pragma warning disable SA1600 // Elements should be documented
+
+    [HarmonyPatch(typeof(ServerRoles), nameof(ServerRoles.CmdServerSignatureComplete))]
+    internal static class Verified
+    {
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var targetMethod = AccessTools.Method(typeof(ServerRoles), nameof(ServerRoles.RefreshPermissions));
+            var did = false;
+
+            foreach (var i in instructions)
+            {
+                yield return i;
+
+                if (!did && i.opcode == OpCodes.Call && (MethodInfo)i.operand == targetMethod)
+                {
+                    did = true;
+
+                    // Think I wanna have a deal with IL?
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Verified), nameof(CallEvent)));
+                }
+            }
+        }
+
+        private static void CallEvent(ServerRoles instance)
+        {
+            try
+            {
+                var player = PlayerAPI.Get(instance.gameObject);
+                player.IsVerified = true;
+
+                PlayerEvents.OnVerified(new VerifiedEventArgs(player));
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"{typeof(Verified).FullName}.{nameof(CallEvent)}:\n{ex}");
+            }
+        }
+    }
+}

--- a/Exiled.Events/Patches/Events/Player/Verified.cs
+++ b/Exiled.Events/Patches/Events/Player/Verified.cs
@@ -33,16 +33,16 @@ namespace Exiled.Events.Patches.Events.Player
 
             foreach (var i in instructions)
             {
-                yield return i;
-
                 if (!did && i.opcode == OpCodes.Call && (MethodInfo)i.operand == targetMethod)
                 {
                     did = true;
 
                     // Think I wanna have a deal with IL?
-                    yield return new CodeInstruction(OpCodes.Ldarg_0);
                     yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Verified), nameof(CallEvent)));
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
                 }
+
+                yield return i;
             }
         }
 


### PR DESCRIPTION
### New behavior
Joined - called once the player's object has been instantiated
Verified - called once the player has been verified
Destroying - called before the player's object is destroyed
Left - called before the player has left the server

Joined event is called right before Verified event is called, after them ChangingGroup event is called.

This was made to fix the current situation where Left event isn't called and during a silent round restart a plugin doesn't know which player is still on the server.