### PR TITLE
Added CurrentSpectatingPlayers and SpectatedPlayer

### DIFF
--- a/Exiled.API/Features/Player.cs
+++ b/Exiled.API/Features/Player.cs
@@ -954,6 +954,48 @@ namespace Exiled.API.Features
         }
 
         /// <summary>
+        /// Gets a <see cref="Player"/> <see cref="IEnumerable{T}"/> of spectators that are currently spectating this <see cref="Player"/>.
+        /// </summary>
+        public IEnumerable<Player> CurrentSpectatingPlayers
+        {
+            get
+            {
+                foreach (ReferenceHub referenceHub in ReferenceHub.spectatorManager.ServerCurrentSpectatingPlayers)
+                {
+                    Player spectator = Get(referenceHub);
+
+                    if (spectator == this || spectator.IsDead)
+                        yield return spectator;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets currently spectated player by this <see cref="Player"/>. May be null.
+        /// </summary>
+        public Player SpectatedPlayer
+        {
+            get
+            {
+                Player spectatedPlayer = Get(ReferenceHub.spectatorManager.CurrentSpectatedPlayer);
+
+                if (spectatedPlayer == this)
+                    return null;
+
+                return spectatedPlayer;
+            }
+
+            set
+            {
+                if (IsAlive)
+                    throw new InvalidOperationException("You cannot set Spectated Player when you are alive!");
+
+                ReferenceHub.spectatorManager.CurrentSpectatedPlayer = value.ReferenceHub;
+                ReferenceHub.spectatorManager.CmdSendPlayer(value.Id);
+            }
+        }
+
+        /// <summary>
         /// Gets a dictionary for storing player objects of connected but not yet verified players.
         /// </summary>
         internal static ConditionalWeakTable<ReferenceHub, Player> UnverifiedPlayers { get; } = new ConditionalWeakTable<ReferenceHub, Player>();


### PR DESCRIPTION
I'm not sure if setter for `SpectatedPlayer` works, I'm am unable to test that because it required at least 3 players, but the rese should work.

`spectator == this` exists, because the base-game method counts the player himself for some reason, it isn't useful so I added the check