### PR TITLE
Fix ChangingGroup event

### DIFF
--- a/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
+++ b/Exiled.Events/Patches/Events/Player/ChangingGroup.cs
@@ -44,7 +44,7 @@ namespace Exiled.Events.Patches.Events.Player
             //     return;
             newInstructions.InsertRange(index, new[]
             {
-                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldarg_0).MoveLabelsFrom(newInstructions[index]),
                 new CodeInstruction(OpCodes.Call, PropertyGetter(typeof(ServerRoles), nameof(ServerRoles.gameObject))),
                 new CodeInstruction(OpCodes.Call, Method(typeof(API.Features.Player), nameof(API.Features.Player.Get), new[] { typeof(GameObject) })),
                 new CodeInstruction(OpCodes.Ldarg_1),


### PR DESCRIPTION
Move label to prevent skipping of inserted code