### PR TITLE
Added GetItemTypes to ItemExtensions

### DIFF
--- a/Exiled.API/Extensions/ItemExtensions.cs
+++ b/Exiled.API/Extensions/ItemExtensions.cs
@@ -167,23 +167,11 @@ namespace Exiled.API.Extensions
         }
 
         /// <summary>
-        /// Converts a <see cref="List{T}"/> of <see cref="Item"/>s into the corresponding <see cref="List{T}"/> of <see cref="ItemType"/>s.
+        /// Converts a <see cref="IEnumerable{T}"/> of <see cref="Item"/>s into the corresponding <see cref="List{T}"/> of <see cref="ItemType"/>s.
         /// </summary>
         /// <param name="items">The items to convert.</param>
         /// <returns>A new <see cref="List{T}"/> of <see cref="ItemType"/>s.</returns>
-        public static List<ItemType> GetItemTypes(this List<Item> items)
-        {
-            List<ItemType> itemTypes = new List<ItemType>();
-            itemTypes.AddRange(items.Select(item => item.Type));
-            return itemTypes;
-        }
-
-        /// <summary>
-        /// Converts a <see cref="IReadOnlyCollection{T}"/> of <see cref="Item"/>s into the corresponding <see cref="List{T}"/> of <see cref="ItemType"/>s.
-        /// </summary>
-        /// <param name="items">The items to convert.</param>
-        /// <returns>A new <see cref="List{T}"/> of <see cref="ItemType"/>s.</returns>
-        public static List<ItemType> GetItemTypes(this IReadOnlyCollection<Item> items)
+        public static List<ItemType> GetItemTypes(this IEnumerable<Item> items)
         {
             List<ItemType> itemTypes = new List<ItemType>();
             itemTypes.AddRange(items.Select(item => item.Type));


### PR DESCRIPTION
This is useful to get a list of itemtypes without having to run a for/foreach loop each time we want to get a list of itemtypes instead of a list of items.