### PR TITLE
Fixed ev.IsAllowed = false not working in PickingUpItem Patch

### DIFF
--- a/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
+++ b/Exiled.Events/Patches/Events/Player/PickingUpItem.cs
@@ -73,6 +73,7 @@ namespace Exiled.Events.Patches.Events.Player
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(ItemSearchCompletor), nameof(ItemSearchCompletor.TargetPickup))),
                 new CodeInstruction(OpCodes.Ldfld, Field(typeof(ItemPickupBase), nameof(ItemPickupBase.Info))),
                 new CodeInstruction(OpCodes.Callvirt, PropertySetter(typeof(ItemPickupBase), nameof(ItemPickupBase.NetworkInfo))),
+                new CodeInstruction(OpCodes.Br, retLabel),
             });
 
             newInstructions[newInstructions.Count - 1].WithLabels(retLabel);


### PR DESCRIPTION
Right now if use set ev.IsAllowed to false in does absolutely nothing. You still pick up the item.
With this fix it works as in Exiled 3.0.5 - if you set it to false, you will not pick up the item but it will be locked forever. (Still can't find how to fix it)