### PR TITLE
`SpawningRagdollEventArgs::Scp096Death` summary fix

### DIFF
--- a/Exiled.Events/EventArgs/SpawningRagdollEventArgs.cs
+++ b/Exiled.Events/EventArgs/SpawningRagdollEventArgs.cs
@@ -132,7 +132,7 @@ namespace Exiled.Events.EventArgs
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the 096Death should be set as ragdoll's property.
+        /// Gets or sets a value indicating whether or not the ragdoll's death is caused by Scp096.
         /// </summary>
         public bool Scp096Death { get; set; }
 


### PR DESCRIPTION
Since I didn't know what Scp096Death was before, I'd like to fix this "typo".