### PR TITLE
Unnecesary checks

### DIFF
--- a/Exiled.Events/Patches/Events/Player/Hurting.cs
+++ b/Exiled.Events/Patches/Events/Player/Hurting.cs
@@ -32,9 +32,6 @@ namespace Exiled.Events.Patches.Events.Player
         {
             try
             {
-                if (go == null)
-                    return true;
-
                 API.Features.Player attacker = API.Features.Player.Get(info.IsPlayer ? info.RHub.gameObject : __instance.gameObject);
                 API.Features.Player target = API.Features.Player.Get(go);
 
@@ -52,10 +49,6 @@ namespace Exiled.Events.Patches.Events.Player
                     return true;
 
                 HurtingEventArgs ev = new HurtingEventArgs(attacker, target, info);
-
-                if (ev.Target.IsHost)
-                    return true;
-
                 Player.OnHurting(ev);
 
                 info = ev.HitInformation;


### PR DESCRIPTION
1st: Player.Get(go) has a null check, so it is unnecesary.
2nd ev.Attacker is the same as attacker which has a server host check before