### PR TITLE
[Resonance] New Feature: Warhead Button Glass Cover Closable

### DIFF
--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -81,9 +81,9 @@ namespace Exiled.Events
         public bool CanKeycardThrowAffectDoors { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets a value indicating whether warhead can be closed or not.
+        /// Gets or sets a value indicating whether the warhead button glass cover can be closed or not.
         /// </summary>
-        [Description("Indicates whether warhead can be closed or not")]
+        [Description("Indicates whether the warhead button glass cover can be closed or not")]
         public bool WarheadButtonClosable { get; set; } = false;
 
         /// <summary>

--- a/Exiled.Events/Config.cs
+++ b/Exiled.Events/Config.cs
@@ -81,6 +81,12 @@ namespace Exiled.Events
         public bool CanKeycardThrowAffectDoors { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether warhead can be closed or not.
+        /// </summary>
+        [Description("Indicates whether warhead can be closed or not")]
+        public bool WarheadButtonClosable { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether configs has to be reloaded every time a round restarts.
         /// </summary>
         [Description("Indicates whether configs have to be reloaded every round restart")]

--- a/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
+++ b/Exiled.Events/Patches/Events/Player/ActivatingWarheadPanel.cs
@@ -129,7 +129,7 @@ namespace Exiled.Events.Patches.Events.Player
                     new(OpCodes.Callvirt, PropertyGetter(typeof(AlphaWarheadOutsitePanel), nameof(AlphaWarheadOutsitePanel.NetworkkeycardEntered))),
                     new(OpCodes.Brfalse_S, openLabel),
 
-                    // if Config::WarheadButtonClosable, goto endLabel
+                    // if Config::WarheadButtonClosable is false, goto endLabel
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Exiled.Events.Events), nameof(Exiled.Events.Events.Instance))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Exiled.Events.Events), nameof(Exiled.Events.Events.Config))),
                     new(OpCodes.Callvirt, PropertyGetter(typeof(Config), nameof(Config.WarheadButtonClosable))),


### PR DESCRIPTION
Now, the question is, what does this do?

It replaces the logic that opens the surface warhead button with a custom one, that allows one more interaction that closes the button (The glass that covers it).

Implemented a new config in Exiled Events that allows to toggle if the glass cover can be closed aswell or not under the name of `WarheadButtonClosable`.

Todo List:

- [x] Implementation
- [ ] Test